### PR TITLE
Avoid powershell interactive mode errors

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -199,7 +199,7 @@ function Request-File
         [string]$saveAs
     )
  
-    Write-Host "Downloading $url to $saveAs"
+    Write-Verbose "Downloading $url to $saveAs"
     $downloader = new-object System.Net.WebClient
     $downloader.DownloadFile($url, $saveAs)
 }


### PR DESCRIPTION
DSC is meant to run in non-interactive mode: replaced Write-Host with
Write-Verbose