### PR TITLE
Added IpAddress optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ First, ensure the OctopusDSC module is on your `$env:PSModulePath`. Then you can
 ```
 Configuration SampleConfig
 {
-    param ($ApiKey, $OctopusServerUrl, $Environments, $Roles, $ListenPort)
+    param ($ApiKey, $OctopusServerUrl, $Environments, $Roles, $ListenPort, $ipAddress)
  
     Import-DscResource -Module OctopusDSC
  
@@ -31,11 +31,12 @@ Configuration SampleConfig
             # Optional settings
             ListenPort = $ListenPort;
             DefaultApplicationDirectory = "C:\Applications"
+            IPAddress = $ipAddress
         }
     }
 }
  
-SampleConfig -ApiKey "API-ABCDEF12345678910" -OctopusServerUrl "https://demo.octopusdeploy.com/" -Environments @("Development") -Roles @("web-server", "app-server") -ListenPort 10933
+SampleConfig -ApiKey "API-ABCDEF12345678910" -OctopusServerUrl "https://demo.octopusdeploy.com/" -Environments @("Development") -Roles @("web-server", "app-server") -ListenPort 10933 -IpAddress "10.123.23.34"
 
 Start-DscConfiguration .\SampleConfig -Verbose -wait
 


### PR DESCRIPTION
In order to support workloads running without public IP Addresses (i.e. Robot Army http://tech.domain.com.au/2015/01/robot-army-v2-0/ ), added an optional parameter $IpAddress. 

so in our specific case, we could use

$ip = irm http://169.254.169.254/latest/meta-data/ip-v4
  SampleConfig -ApiKey "API-ABCDEF12345678910" -OctopusServerUrl "https://10.123.15.25/" -Environments @("Development") -Roles @("web-server", "app-server") -ListenPort 10933 -IpAddress $ip

Also updated the readme with example parameter
