### PR TITLE
Allows a dns name to be specified in place of autodetecting IP addresses

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -69,6 +69,10 @@ function Set-TargetResource
         [ValidateNotNullOrEmpty()]
         [string]$Name,
 
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Thumbprint,
+        
         [ValidateSet("Started", "Stopped")]
         [string]$State = "Started",
         
@@ -126,7 +130,7 @@ function Set-TargetResource
     elseif ($Ensure -eq "Present" -and $currentResource["Ensure"] -eq "Absent") 
     {
         Write-Verbose "Installing Tentacle..."
-        New-Tentacle -name $Name -apiKey $ApiKey -octopusServerUrl $OctopusServerUrl -port $ListenPort -environments $Environments -roles $Roles -DefaultApplicationDirectory $DefaultApplicationDirectory -PublicDnsName $PublicDnsName
+        New-Tentacle -name $Name -thumbprint $Thumbprint -apiKey $ApiKey -octopusServerUrl $OctopusServerUrl -port $ListenPort -environments $Environments -roles $Roles -DefaultApplicationDirectory $DefaultApplicationDirectory -PublicDnsName $PublicDnsName
         Write-Verbose "Tentacle installed!"
     }
 
@@ -149,6 +153,10 @@ function Test-TargetResource
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$Name,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Thumbprint,
 
         [ValidateSet("Started", "Stopped")]
         [string]$State = "Started",
@@ -234,6 +242,8 @@ function New-Tentacle
         [Parameter(Mandatory=$True)]
         [string]$name,
         [Parameter(Mandatory=$True)]
+        [string]$thumbprint,
+        [Parameter(Mandatory=$True)]
         [string]$apiKey,
         [Parameter(Mandatory=$True)]
         [string]$octopusServerUrl,
@@ -311,10 +321,12 @@ function New-Tentacle
     $tentacleAppDirectory = $DefaultApplicationDirectory
     $tentacleConfigFile = "$($env:SystemDrive)\Octopus\$Name\Tentacle.config"
     Invoke-AndAssert { & .\tentacle.exe create-instance --instance $name --config $tentacleConfigFile --console }
+    Invoke-AndAssert { & .\tentacle.exe new-certificate --instance $name --if-blank --console }
+    Invoke-AndAssert { & .\tentacle.exe configure --instance $name --reset-trust --console }
     Invoke-AndAssert { & .\tentacle.exe configure --instance $name --home $tentacleHomeDirectory --console }
     Invoke-AndAssert { & .\tentacle.exe configure --instance $name --app $tentacleAppDirectory --console }
     Invoke-AndAssert { & .\tentacle.exe configure --instance $name --port $port --console }
-    Invoke-AndAssert { & .\tentacle.exe new-certificate --instance $name --console }
+    Invoke-AndAssert { & .\tentacle.exe configure --instance $name --trust $thumbprint --console }
     Invoke-AndAssert { & .\tentacle.exe service --install --instance $name --console }
 
     $registerArguments = @("register-with", "--instance", $name, "--server", $octopusServerUrl, "--name", $env:COMPUTERNAME, "--publicHostName", $ipAddress, "--apiKey", $apiKey, "--comms-style", "TentaclePassive", "--force", "--console")

--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
@@ -6,6 +6,7 @@ class cTentacleAgent : OMI_BaseResource
   [Write,ValueMap{"Started","Stopped"},Values{"Started", "Stopped"}] string State;
 
   [Write] string ApiKey;
+  [Write] string Thumbprint;
   [Write] string OctopusServerUrl;
   [Write] string Environments[];
   [Write] string Roles[];

--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
@@ -11,4 +11,5 @@ class cTentacleAgent : OMI_BaseResource
   [Write] string Roles[];
   [Write] UInt32 ListenPort;
   [Write] string DefaultApplicationDirectory;
+  [Write] string PublicDnsName;
 };


### PR DESCRIPTION
We're autoprovisioning machines using Azure Resource Manager, and find it more reliable to provide names instead of using a third party service to figure out the machine's IP address, as the latter regularly times out.
