### PR TITLE
Add support for TLS protocols

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -207,7 +207,12 @@ function Request-File
  
     Write-Verbose "Downloading $url to $saveAs"
     [System.Net.ServicePointManager]::Expect100Continue = $true;
-    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+    [System.Net.ServicePointManager]::SecurityProtocol = `
+        [System.Net.SecurityProtocolType]::Ssl3 -bor `
+        [System.Net.SecurityProtocolType]::Tls -bor `
+        [System.Net.SecurityProtocolType]::Tls11 -bor `
+        [System.Net.SecurityProtocolType]::Tls12
+        
     $downloader = new-object System.Net.WebClient
     $downloader.DownloadFile($url, $saveAs)
 }

--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -206,6 +206,8 @@ function Request-File
     )
  
     Write-Verbose "Downloading $url to $saveAs"
+    [System.Net.ServicePointManager]::Expect100Continue = $true;
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
     $downloader = new-object System.Net.WebClient
     $downloader.DownloadFile($url, $saveAs)
 }


### PR DESCRIPTION
The OctopusDSC module fails with `Exception calling "DownloadFile" with "2" argument(s): "The request was aborted: Could not create SSL/TLS secure channel."` when it attempts to download the latest Tentacle MSIs
