### PR TITLE
Provide host name parameters to Get-PublicHostName

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -407,7 +407,7 @@ function New-Tentacle
 
     if ($CommunicationMode -eq "Listen") {
         Invoke-AndAssert { & .\tentacle.exe configure --instance $name --port $port --console }
-        $publicHostName = Get-PublicHostName
+        $publicHostName = Get-PublicHostName $publicHostNameConfiguration $customPublicHostName
         Write-Verbose "Public host name: $publicHostName"
         $registerArguments += @("--comms-style", "TentaclePassive",
                                 "--publicHostName", $publicHostName)


### PR DESCRIPTION
The host name parameters was not sent to Get-PublicHostName which resulted in that the default value always was used no matter what.