### PR TITLE
Tenant and TenantTags functionality added

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -19,6 +19,8 @@ function Get-TargetResource
         [string]$OctopusServerUrl,
         [string[]]$Environments,
         [string[]]$Roles,
+        [string[]]$Tenants = "",
+        [string[]]$TenantTags = "",
         [string]$DefaultApplicationDirectory,
         [int]$ListenPort=10933,
         [int]$ServerPort=10943,
@@ -91,6 +93,8 @@ function Set-TargetResource
         [string]$DisplayName = "$($env:COMPUTERNAME)_$Name",
         [string[]]$Environments,
         [string[]]$Roles,
+        [string[]]$Tenants = "",
+        [string[]]$TenantTags = "",
         [string]$DefaultApplicationDirectory = "$($env:SystemDrive)\Applications",
         [int]$ListenPort = 10933,
         [int]$ServerPort = 10943,
@@ -170,6 +174,8 @@ function Set-TargetResource
                      -displayName $DisplayName `
                      -environments $Environments `
                      -roles $Roles `
+                     -tenants $Tenants `
+                     -tenanttags $TenantTags `
                      -DefaultApplicationDirectory $DefaultApplicationDirectory `
                      -tentacleDownloadUrl $tentacleDownloadUrl `
                      -tentacleDownloadUrl64 $tentacleDownloadUrl64 `
@@ -219,6 +225,8 @@ function Test-TargetResource
         [string]$DisplayName = "$($env:COMPUTERNAME)_$Name",
         [string[]]$Environments,
         [string[]]$Roles,
+        [string[]]$Tenants = "",
+        [string[]]$TenantTags = "",
         [string]$DefaultApplicationDirectory,
         [int]$ListenPort=10933,
         [int]$ServerPort=10943,
@@ -361,6 +369,10 @@ function New-Tentacle
         [string[]]$environments,
         [Parameter(Mandatory=$True)]
         [string[]]$roles,
+        [Parameter(Mandatory=$False)]
+        [string[]]$Tenants = "",
+        [Parameter(Mandatory=$False)]
+        [string[]]$TenantTags = "",
         [int]$port=10933,
         [string]$displayName,
         [string]$DefaultApplicationDirectory,
@@ -437,12 +449,37 @@ function New-Tentacle
             $registerArguments += $e2.Trim()
         }
     }
+
     foreach ($role in $roles)
     {
         foreach ($r2 in $role.Split(','))
         {
             $registerArguments += "--role"
             $registerArguments += $r2.Trim()
+        }
+    }
+
+    if ($tenants -ne "")
+    {
+        foreach ($tenant in $tenants)
+        {
+            foreach ($t2 in $tenant.Split(','))
+            {
+                $registerArguments += "--tenant"
+                $registerArguments += $t2.Trim()
+            }
+        }
+    }
+
+    if ($tenanttags -ne "")
+    {
+        foreach ($tenanttag in $tenanttags)
+        {
+            foreach ($tt2 in $tenanttag.Split(','))
+            {
+                $registerArguments += "--tenanttag"
+                $registerArguments += $tt2.Trim()
+            }
         }
     }
 

--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
@@ -1,4 +1,4 @@
-﻿[ClassVersion("1.0.0"), FriendlyName("cTentacleAgent")]
+[ClassVersion("1.0.0"), FriendlyName("cTentacleAgent")]
 class cTentacleAgent : OMI_BaseResource
 {
   [Key] string Name;
@@ -11,6 +11,8 @@ class cTentacleAgent : OMI_BaseResource
   [Write] string DisplayName;
   [Write] string Environments[];
   [Write] string Roles[];
+  [Write] string Tenants[];
+  [Write] string TenantTags[];
   [Write] UInt32 ListenPort;
   [Write] UInt32 ServerPort;
   [Write] string DefaultApplicationDirectory;


### PR DESCRIPTION
Adds the ability to specify tags for tenants and tenanttags functionality in the Tentacle Agent DSC module. If no tags are specified then the switches aren't added to the invocation string allowing for backwards compatibility. 