### PR TITLE
Fix polling to handle weblistenprefixes

### DIFF
--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
@@ -551,7 +551,7 @@ function Start-OctopusDeployService($name, $webListenPrefix)
       Start-Sleep -Seconds 5
   }
 
-  if (-not Test-OctopusDeployServerResponding $url) {
+  if (-not (Test-OctopusDeployServerResponding $url)) {
     throw "Server did not come online at $url after $($timeout.TotalMinutes) minutes"
   }
 }


### PR DESCRIPTION
Fixes #85.

Allow `weblistenprefix`es to be delimted on commas as well as semicolons.

Also throw an error if we hit the timeout, rather than just pretending it worked.