### PR TITLE
Fix up tentacle service creds

### DIFF
--- a/Tests/Gemfile.lock
+++ b/Tests/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     net-telnet (0.1.1)
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
-    octopus-serverspec-extensions (0.12.2)
+    octopus-serverspec-extensions (0.13.3)
       json (= 1.8.3)
       rspec (~> 3.0)
       serverspec (~> 2)

--- a/Tests/Scenarios/Tentacle_Scenario_01_Install.ps1
+++ b/Tests/Scenarios/Tentacle_Scenario_01_Install.ps1
@@ -162,7 +162,7 @@ Configuration Tentacle_Scenario_01_Install
             CommunicationMode = "Listen"
             TentacleHomeDirectory = "C:\Octopus\ListeningTentacleWithCustomAccountHome"
 
-            TentacleServiceCredential = $serviceusercredential
+            TentacleServiceCredential = $svccred
             DependsOn = "[user]ServiceUser"
         }
     }

--- a/Tests/Spec/server_scenario_10_install4_spec.rb
+++ b/Tests/Spec/server_scenario_10_install4_spec.rb
@@ -39,7 +39,7 @@ describe service('OctopusDeploy') do
   it { should be_installed }
   it { should be_running }
   it { should have_start_mode('Automatic') }
-  it { should run_under_account('OctoSquid') }
+  it { should run_under_account('.\OctoSquid') }
 end
 
 describe port(10943) do

--- a/Tests/Spec/tentacle_scenario_01_install_spec.rb
+++ b/Tests/Spec/tentacle_scenario_01_install_spec.rb
@@ -142,7 +142,7 @@ describe service('OctopusDeploy Tentacle: ListeningTentacleWithCustomAccount') d
   it { should be_installed }
   it { should be_running }
   it { should have_start_mode('Automatic') }
-  it { should run_under_account('serviceuser') }
+  it { should run_under_account('.\ServiceUser') }
 end
 
 describe port(10936) do


### PR DESCRIPTION
We weren't actually setting the credentials, and the tests were not working correctly, so it wasn't detecting the issue.

I did try and use the `Set-ServiceCredential` and `Get-ServiceUsername` functions, but ran into issues where the account didn't have "Logon as a service" rights. This is handled inside the `tentacle.exe service` command, so just used that.

Fixes #84