### PR TITLE
Remove mandatory flag for $apiKey and $octopusServerUrl params

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -77,6 +77,7 @@ function Get-TargetResource {
 
 # test a variable has a value (whether its an array or string)
 function Test-Value($value) {
+    if ($null -eq $value) { return $false }
     if ($value -eq "") { return $false }
     if ($value.length -eq 0) { return $false }
     if ($value.length -eq 1 -and $value[0].length -eq 0) { return $false }
@@ -90,16 +91,39 @@ function Confirm-RegistrationParameter {
         [string[]]$Roles,
         [string]$Policy,
         [string[]]$Tenants,
-        [string[]]$TenantTags
+        [string[]]$TenantTags,
+        [string]$OctopusServerUrl,
+        [string]$ApiKey
     )
-    if ($RegisterWithServer) {
-        return
-    }
 
-    if ((Test-Value($Roles)) -or (Test-Value($Environments)) -or (Test-Value($Tenants)) -or (Test-Value($TenantTags)) -or (Test-Value($Policy))) {
+    if ((Test-Value($Roles)) -and (-not ($RegisterWithServer))) {
         throw "Invalid configuration requested. " + `
-            "You have asked for the Tentacle not to be registered with the server, but still provided a server specific configuration argument (Roles, Environments, Tenants, TenantTags or Policy). " + `
-            "Please remove the configuration argument or set 'RegisterWithServer = `$True'."
+            "You have asked for the Tentacle not to be registered with the server, but still provided a the 'Roles' configuration argument. " + `
+            "Please remove the 'Roles' configuration argument or set 'RegisterWithServer = `$True'."
+    } elseif ((Test-Value($Environments)) -and (-not ($RegisterWithServer))) {
+        throw "Invalid configuration requested. " + `
+            "You have asked for the Tentacle not to be registered with the server, but still provided a the 'Environments' configuration argument. " + `
+            "Please remove the 'Environments' configuration argument or set 'RegisterWithServer = `$True'."
+    } elseif ((Test-Value($Tenants)) -and (-not ($RegisterWithServer))) {
+        throw "Invalid configuration requested. " + `
+            "You have asked for the Tentacle not to be registered with the server, but still provided a the 'Tenants' configuration argument. " + `
+            "Please remove the 'Tenants' configuration argument or set 'RegisterWithServer = `$True'."
+    } elseif ((Test-Value($TenantTags)) -and (-not ($RegisterWithServer))) {
+        throw "Invalid configuration requested. " + `
+            "You have asked for the Tentacle not to be registered with the server, but still provided a the 'TenantTags' configuration argument. " + `
+            "Please remove the 'TenantTags' configuration argument or set 'RegisterWithServer = `$True'."
+    } elseif ((Test-Value($Policy)) -and (-not ($RegisterWithServer))) {
+        throw "Invalid configuration requested. " + `
+            "You have asked for the Tentacle not to be registered with the server, but still provided a the 'Policy' configuration argument. " + `
+            "Please remove the 'Policy' configuration argument or set 'RegisterWithServer = `$True'."
+    } elseif ((-not (Test-Value($OctopusServerUrl))) -and (($RegisterWithServer))) {
+        throw "Invalid configuration requested. " + `
+            "You have asked for the Tentacle to be registered with the server, but not provided the 'OctopusServerUrl' configuration argument. " + `
+            "Please specify the 'OctopusServerUrl' configuration argument or set 'RegisterWithServer = `$False'."
+    } elseif ((-not (Test-Value($ApiKey))) -and (($RegisterWithServer))) {
+        throw "Invalid configuration requested. " + `
+            "You have asked for the Tentacle to be registered with the server, but not provided the 'ApiKey' configuration argument. " + `
+            "Please specify the 'ApiKey' configuration argument or set 'RegisterWithServer = `$False'."
     }
 }
 
@@ -156,7 +180,10 @@ function Set-TargetResource {
         -Roles $Roles `
         -Policy $Policy `
         -Tenants $Tenants `
-        -TenantTags $TenantTags
+        -TenantTags $TenantTags `
+        -OctopusServerUrl $OctopusServerUrl `
+        -ApiKey $ApiKey
+
 
     $currentResource = (Get-TargetResource -Name $Name)
 

--- a/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
@@ -43,6 +43,12 @@ try
                 It 'Throws if RegisterWithServer is false but policy provided' {
                     { Confirm-RegistrationParameter -RegisterWithServer $False -Policy "my policy" } | Should Throw "Invalid configuration requested"
                 }
+                It 'Throws if RegisterWithServer is true but no OctopusServerUrl provided' {
+                    { Confirm-RegistrationParameter -RegisterWithServer $true -OctopusServerUrl $null } | Should Throw "Invalid configuration requested"
+                }
+                It 'Throws if RegisterWithServer is true but no ApiKey provided' {
+                    { Confirm-RegistrationParameter -RegisterWithServer $true -OctopusServerUrl "https://example.octopus.com" -ApiKey $null } | Should Throw "Invalid configuration requested"
+                }
                 It 'Does not throw if RegisterWithServer is false and environment provided as empty string' {
                     Confirm-RegistrationParameter -RegisterWithServer $False -Environments ""
                 }
@@ -54,6 +60,9 @@ try
                 }
                 It 'Does not throw if RegisterWithServer is false and no environment provided' {
                     Confirm-RegistrationParameter -RegisterWithServer $False
+                }
+                It 'Does not throw if RegisterWithServer is true and OctopusServerUrl and ApiKey     provided' {
+                    Confirm-RegistrationParameter -RegisterWithServer $true -OctopusServerUrl "https://example.octopus.com" -ApiKey "API-1234"
                 }
             }
 

--- a/Tests/Scenarios/Tentacle_Scenario_01_Install.ps1
+++ b/Tests/Scenarios/Tentacle_Scenario_01_Install.ps1
@@ -84,10 +84,6 @@ Configuration Tentacle_Scenario_01_Install
             # than one instance
             Name = "ListeningTentacleWithoutAutoRegister";
 
-            # Registration - all parameters required
-            ApiKey = $ApiKey;
-            OctopusServerUrl = $OctopusServerUrl;
-
             # Optional settings
             ListenPort = 10934;
             DefaultApplicationDirectory = "C:\Applications"
@@ -105,10 +101,6 @@ Configuration Tentacle_Scenario_01_Install
             # Tentacle instance name. Leave it as 'Tentacle' unless you have more
             # than one instance
             Name = "ListeningTentacleWithThumbprintWithoutAutoRegister";
-
-            # Registration - all parameters required
-            ApiKey = $ApiKey;
-            OctopusServerUrl = $OctopusServerUrl;
 
             # Optional settings
             ListenPort = 10935;


### PR DESCRIPTION
As they are only mandatory if `$registerWithServer` is set to `$true`. 

Fixes #89 