### PR TITLE
Dont always try to grant database permissions

### DIFF
--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.schema.mof
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.schema.mof
@@ -17,4 +17,5 @@ class cOctopusServer : OMI_BaseResource
   [Write, EmbeddedInstance ("MSFT_Credential")] string OctopusServiceCredential;
   [Write] string HomeDirectory;
   [Write] string LicenseKey;
+  [Write] boolean GrantDatabasePermissions;
 };

--- a/README-cOctopusServer.md
+++ b/README-cOctopusServer.md
@@ -92,6 +92,7 @@ When `State` is `Started`, the resource will ensure that the Octopus Servr windo
 | `OctopusServiceCredential`                   | `PSCredential`                                      |                                                                 | Credentials of the account used to run the Octopus Service |
 | `HomeDirectory`                              | `string`                                            | `C:\Octopus`                                                    | Home directory for Octopus logs and config (where supported) |
 | `LicenseKey`                                 | `string`                                            |                                                                 | The Base64 (UTF8) encoded license key. If not supplied, uses a free license. Drift detection is only supported from Octopus 4.1.3. |
+| `GrantDatabasePermissions`                   | `boolean`                                           | `$true`                                                         | Whether to grant `db_owner` permissions to the service account user (`$OctopusServiceCredential` user if supplied, or `NT AUTHORITY\System`)  |
 
 ## Drift
 


### PR DESCRIPTION
As it now fails on octopus 4.1+ if the user doesn't have rights to do so (it used to swallow the error before)