### PR TITLE
Hyper-V bug fixes

### DIFF
--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
@@ -249,7 +249,7 @@ function Test-OctopusVersionSupportsAutoLoginEnabled {
     return Test-OctopusVersionNewerThan (New-Object System.Version 3, 5, 0)
 }
 
-function Test-OctopusVersionSupportsHsts {
+function Test-OctopusVersionSupportsHst {
     return Test-OctopusVersionNewerThan (New-Object System.Version 3, 13, 0)
 }
 
@@ -489,7 +489,7 @@ function Set-OctopusDeployConfiguration {
         }
     }
 
-    if (Test-OctopusVersionSupportsHsts) {
+    if (Test-OctopusVersionSupportsHst) {
         $args += @(
             '--hstsEnabled', $hstsEnabled,
             '--hstsMaxAge', $hstsMaxAge
@@ -991,7 +991,7 @@ function Install-OctopusDeploy {
         throw "AutoLoginEnabled is only supported from Octopus 3.5.0."
     }
 
-    if (Test-OctopusVersionSupportsHsts) {
+    if (Test-OctopusVersionSupportsHst) {
         $args += @(
             '--hstsEnabled', $hstsEnabled,
             '--hstsMaxAge', $hstsMaxAge

--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
@@ -249,7 +249,9 @@ function Test-OctopusVersionSupportsAutoLoginEnabled {
     return Test-OctopusVersionNewerThan (New-Object System.Version 3, 5, 0)
 }
 
-function Test-OctopusVersionSupportsHst {
+function Test-OctopusVersionSupportsHsts {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
+    param()
     return Test-OctopusVersionNewerThan (New-Object System.Version 3, 13, 0)
 }
 
@@ -489,7 +491,7 @@ function Set-OctopusDeployConfiguration {
         }
     }
 
-    if (Test-OctopusVersionSupportsHst) {
+    if (Test-OctopusVersionSupportsHsts) {
         $args += @(
             '--hstsEnabled', $hstsEnabled,
             '--hstsMaxAge', $hstsMaxAge
@@ -991,7 +993,7 @@ function Install-OctopusDeploy {
         throw "AutoLoginEnabled is only supported from Octopus 3.5.0."
     }
 
-    if (Test-OctopusVersionSupportsHst) {
+    if (Test-OctopusVersionSupportsHsts) {
         $args += @(
             '--hstsEnabled', $hstsEnabled,
             '--hstsMaxAge', $hstsMaxAge

--- a/OctopusDSC/Tests/cOctopusServer.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServer.Tests.ps1
@@ -105,7 +105,7 @@ try
                     Mock Test-OctopusVersionSupportsHomeDirectoryDuringCreateInstance { return $true }
                     Mock Test-OctopusVersionRequiresDatabaseBeforeConfigure { return $true }
                     Mock Test-OctopusVersionSupportsAutoLoginEnabled { return $true }
-                    Mock Test-OctopusVersionSupportsHst { return $true }
+                    Mock Test-OctopusVersionSupportsHsts { return $true }
                     Mock Test-OctopusVersionSupportsShowConfiguration { return $true }
                     Mock Test-OctopusVersionNewerThan { return $true }
                     Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
@@ -155,7 +155,7 @@ try
                     Mock Test-OctopusVersionSupportsHomeDirectoryDuringCreateInstance { return $true }
                     Mock Test-OctopusVersionRequiresDatabaseBeforeConfigure { return $true }
                     Mock Test-OctopusVersionSupportsAutoLoginEnabled { return $true }
-                    Mock Test-OctopusVersionSupportsHst { return $true }
+                    Mock Test-OctopusVersionSupportsHsts { return $true }
                     Mock Test-OctopusVersionSupportsShowConfiguration { return $true }
                     Mock Test-OctopusVersionNewerThan { return $true }
                     Mock Test-OctopusVersionSupportsRunAsCredential { return $true }
@@ -206,7 +206,7 @@ try
                     Mock Test-OctopusVersionSupportsHomeDirectoryDuringCreateInstance { return $true }
                     Mock Test-OctopusVersionRequiresDatabaseBeforeConfigure { return $true }
                     Mock Test-OctopusVersionSupportsAutoLoginEnabled { return $true }
-                    Mock Test-OctopusVersionSupportsHst { return $true }
+                    Mock Test-OctopusVersionSupportsHsts { return $true }
                     Mock Test-OctopusVersionSupportsShowConfiguration { return $true }
                     Mock Test-OctopusVersionNewerThan { return $true }
                     Mock Test-OctopusVersionSupportsRunAsCredential { return $true }

--- a/OctopusDSC/Tests/cOctopusServer.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServer.Tests.ps1
@@ -105,7 +105,7 @@ try
                     Mock Test-OctopusVersionSupportsHomeDirectoryDuringCreateInstance { return $true }
                     Mock Test-OctopusVersionRequiresDatabaseBeforeConfigure { return $true }
                     Mock Test-OctopusVersionSupportsAutoLoginEnabled { return $true }
-                    Mock Test-OctopusVersionSupportsHsts { return $true }
+                    Mock Test-OctopusVersionSupportsHst { return $true }
                     Mock Test-OctopusVersionSupportsShowConfiguration { return $true }
                     Mock Test-OctopusVersionNewerThan { return $true }
                     Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
@@ -155,7 +155,7 @@ try
                     Mock Test-OctopusVersionSupportsHomeDirectoryDuringCreateInstance { return $true }
                     Mock Test-OctopusVersionRequiresDatabaseBeforeConfigure { return $true }
                     Mock Test-OctopusVersionSupportsAutoLoginEnabled { return $true }
-                    Mock Test-OctopusVersionSupportsHsts { return $true }
+                    Mock Test-OctopusVersionSupportsHst { return $true }
                     Mock Test-OctopusVersionSupportsShowConfiguration { return $true }
                     Mock Test-OctopusVersionNewerThan { return $true }
                     Mock Test-OctopusVersionSupportsRunAsCredential { return $true }
@@ -206,7 +206,7 @@ try
                     Mock Test-OctopusVersionSupportsHomeDirectoryDuringCreateInstance { return $true }
                     Mock Test-OctopusVersionRequiresDatabaseBeforeConfigure { return $true }
                     Mock Test-OctopusVersionSupportsAutoLoginEnabled { return $true }
-                    Mock Test-OctopusVersionSupportsHsts { return $true }
+                    Mock Test-OctopusVersionSupportsHst { return $true }
                     Mock Test-OctopusVersionSupportsShowConfiguration { return $true }
                     Mock Test-OctopusVersionNewerThan { return $true }
                     Mock Test-OctopusVersionSupportsRunAsCredential { return $true }

--- a/build-hyperv.ps1
+++ b/build-hyperv.ps1
@@ -63,7 +63,7 @@ Write-Output "Hyper-V installed - good."
 
 if (-not (Get-VMSwitch -SwitchType External -Name 'External Connection' -ErrorAction SilentlyContinue)) {
     Write-Output "Please create an external virtual switch named 'External Connection'."
-        exit 1
+    exit 1
 }
 Write-Output "External virtual switch detected - good."
 


### PR DESCRIPTION
build-hyperv.ps1 was still checking for VirtualBox prerequisites. I replaced this bit with Hyper-V checks.

Also had to remove the trailing 's' from the Test-OctopusVersionSupportsHsts function, as it was causing a PsScriptAnalyzer Pester test to fail with the following:

RuleName                            Severity     ScriptName Line  Message        
--------                            --------     ---------- ----  -------        
PSUseSingularNouns                  Warning      cOctopusSe 252   The cmdlet 'Tes
                                                 rver.psm1        t-OctopusVersio
                                                                  nSupportsHsts' 
                                                                  uses a plural  
                                                                  noun. A        
                                                                  singular noun  
                                                                  should be used 
                                                                  instead. 