### PR TITLE
Add some debug logging to figure out why build is failing

### DIFF
--- a/Tests/Scenarios/Server_Scenario_07_Reinstall.ps1
+++ b/Tests/Scenarios/Server_Scenario_07_Reinstall.ps1
@@ -69,6 +69,8 @@ Configuration Server_Scenario_07_Reinstall
                 $user = $repository.Users.GetCurrent()
                 $createApiKeyResult = $repository.Users.CreateApiKey($user, "Octopus DSC Testing")
 
+                write-verbose "setting OctopusApiKey to $($createApiKeyResult.ApiKey)"
+
                 #save it to enviornment variables for tests to use
                 [environment]::SetEnvironmentVariable("OctopusServerUrl", "http://localhost:81", "User")
                 [environment]::SetEnvironmentVariable("OctopusServerUrl", "http://localhost:81", "Machine")


### PR DESCRIPTION
And for some reason, it now works with this log line in it.
Going with the theory that logging this during build isn't a security issue, as its a short lived instance.