### PR TITLE
Added the ability to add trusted servers to the configuration for HA …

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
@@ -25,5 +25,6 @@ class cTentacleAgent : OMI_BaseResource
   [Write] string TentacleHomeDirectory;
   [Write] Boolean RegisterWithServer;
   [Write] String OctopusServerThumbprint;
+  [Write] string TrustedServers[];
   [Write, EmbeddedInstance ("MSFT_Credential")] string TentacleServiceCredential;
 };


### PR DESCRIPTION
This PR adds the ability to add trusted servers that will be used in a HA configuration.  It is a bit hacky in that it modifies the configuration file to do this.  Use the following optional parameter when using polling mode:

TrustedServers=@('https://testserver01:10943', 'https://testserver02:10943', 'https://testserver03:10943', 'https://testserver04:10943')

Let me know what you think, I know we probably need to update documentation etc, this is just a first attempt at this.