### PR TITLE
Update the seq logging to use the BufferingWrapper

### DIFF
--- a/OctopusDSC/Tests/SampleConfigs/octopus.server.exe.nlog-with-old-sync-configuration-with-api-key.xml
+++ b/OctopusDSC/Tests/SampleConfigs/octopus.server.exe.nlog-with-old-sync-configuration-with-api-key.xml
@@ -32,11 +32,9 @@
     <target xsi:type="ColoredConsole" name="stderr" errorStream="true" layout="${messageLayout}" />
     <target xsi:type="EventLog" name="eventlog" source="${appName}" layout="${normalLayout}" />
     <target xsi:type="RecentInMemory" name="recent" bufferSize="100" />
-    <target name="seqbufferingwrapper" xsi:type="BufferingWrapper" bufferSize="1000" flushTimeout="2000">
-      <target name="seq" xsi:type="Seq" serverUrl="https://seq.example.com">
-        <property name="Application" value="Octopus" />
-        <property name="Server" value="MyServer" />
-      </target>
+    <target name="seq" xsi:type="Seq" serverUrl="https://seq.example.com" apiKey="1a2b3c4d5e6f" >
+      <property name="Application" value="Octopus" />
+      <property name="Server" value="MyServer" />
     </target>
   </targets>
 
@@ -47,6 +45,6 @@
     <logger name="*" minlevel="Warn" writeTo="recent" />
     <logger name="*" minlevel="Info" maxLevel="Warn" writeTo="stdout" />
     <logger name="*" minlevel="Error" writeTo="stderr" />
-    <logger name="*" minlevel="Info" writeTo="seqbufferingwrapper" />
+    <logger name="*" minlevel="Info" writeTo="seq" />
   </rules>
 </nlog>

--- a/OctopusDSC/Tests/SampleConfigs/octopus.server.exe.nlog-with-old-sync-configuration.xml
+++ b/OctopusDSC/Tests/SampleConfigs/octopus.server.exe.nlog-with-old-sync-configuration.xml
@@ -32,11 +32,9 @@
     <target xsi:type="ColoredConsole" name="stderr" errorStream="true" layout="${messageLayout}" />
     <target xsi:type="EventLog" name="eventlog" source="${appName}" layout="${normalLayout}" />
     <target xsi:type="RecentInMemory" name="recent" bufferSize="100" />
-    <target name="seqbufferingwrapper" xsi:type="BufferingWrapper" bufferSize="1000" flushTimeout="2000">
-      <target name="seq" xsi:type="Seq" serverUrl="https://seq.example.com">
-        <property name="Application" value="Octopus" />
-        <property name="Server" value="MyServer" />
-      </target>
+    <target name="seq" xsi:type="Seq" serverUrl="https://seq.example.com">
+      <property name="Application" value="Octopus" />
+      <property name="Server" value="MyServer" />
     </target>
   </targets>
 
@@ -47,6 +45,6 @@
     <logger name="*" minlevel="Warn" writeTo="recent" />
     <logger name="*" minlevel="Info" maxLevel="Warn" writeTo="stdout" />
     <logger name="*" minlevel="Error" writeTo="stderr" />
-    <logger name="*" minlevel="Info" writeTo="seqbufferingwrapper" />
+    <logger name="*" minlevel="Info" writeTo="seq" />
   </rules>
 </nlog>

--- a/OctopusDSC/Tests/SampleConfigs/octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml
+++ b/OctopusDSC/Tests/SampleConfigs/octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml
@@ -32,9 +32,11 @@
     <target xsi:type="ColoredConsole" name="stderr" errorStream="true" layout="${messageLayout}" />
     <target xsi:type="EventLog" name="eventlog" source="${appName}" layout="${normalLayout}" />
     <target xsi:type="RecentInMemory" name="recent" bufferSize="100" />
-    <target name="seq" xsi:type="Seq" serverUrl="https://seq.example.com" apiKey="1a2b3c4d5e6f" >
-      <property name="Application" value="Octopus" />
-      <property name="Server" value="MyServer" />
+    <target name="seqbufferingwrapper" xsi:type="BufferingWrapper" bufferSize="1000" flushTimeout="2000">
+      <target name="seq" xsi:type="Seq" serverUrl="https://seq.example.com" apiKey="1a2b3c4d5e6f" >
+        <property name="Application" value="Octopus" />
+        <property name="Server" value="MyServer" />
+      </target>
     </target>
   </targets>
 
@@ -45,6 +47,6 @@
     <logger name="*" minlevel="Warn" writeTo="recent" />
     <logger name="*" minlevel="Info" maxLevel="Warn" writeTo="stdout" />
     <logger name="*" minlevel="Error" writeTo="stderr" />
-    <logger name="*" minlevel="Info" writeTo="seq" />
+    <logger name="*" minlevel="Info" writeTo="seqbufferingwrapper" />
   </rules>
 </nlog>


### PR DESCRIPTION
As per the latest recommendations from seq - https://github.com/datalust/nlog-targets-seq#nlogtargetsseq----

Auto migrates old synchronous config to the new async, buffered config.