### PR TITLE
Surfaceartifacts

### DIFF
--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
@@ -5,7 +5,7 @@ $script:instancecontext = ''  # a global to hold the name of the current instanc
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
 
-function Resolve-ODSCError
+function Resolve-OctopusDSCError
 {
     param (
         $ErrorRecord=$Error[0]
@@ -210,7 +210,7 @@ function Get-TargetResource {
 
         return $currentResource
     } catch {
-        Resolve-ODSCError $_
+        Resolve-OctopusDSCError $_
         throw
     }
 }
@@ -544,7 +544,7 @@ function Set-TargetResource {
             Start-OctopusDeployService -name $Name -webListenPrefix $webListenPrefix
         }
     } catch {
-        Resolve-ODSCError $_
+        Resolve-OctopusDSCError $_
         throw
     }
 }
@@ -1531,7 +1531,7 @@ function Test-TargetResource {
 
         return $currentConfigurationMatchesRequestedConfiguration
     } catch {
-        Resolve-ODSCError $_
+        Resolve-OctopusDSCError $_
         throw
     }
 }

--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
@@ -5,7 +5,7 @@ $script:instancecontext = ''  # a global to hold the name of the current instanc
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
 
-function Resolve-Error
+function Resolve-ODSCError
 {
     param (
         $ErrorRecord=$Error[0]
@@ -210,7 +210,7 @@ function Get-TargetResource {
 
         return $currentResource
     } catch {
-        Resolve-Error $_
+        Resolve-ODSCError $_
         throw
     }
 }
@@ -544,7 +544,7 @@ function Set-TargetResource {
             Start-OctopusDeployService -name $Name -webListenPrefix $webListenPrefix
         }
     } catch {
-        Resolve-Error $_
+        Resolve-ODSCError $_
         throw
     }
 }
@@ -1531,7 +1531,7 @@ function Test-TargetResource {
 
         return $currentConfigurationMatchesRequestedConfiguration
     } catch {
-        Resolve-Error $_
+        Resolve-ODSCError $_
         throw
     }
 }

--- a/Tests/surface-logs.ps1
+++ b/Tests/surface-logs.ps1
@@ -1,0 +1,59 @@
+Function Get-ConfigPath
+{
+    $files = Get-ChildItem "C:\ProgramData\Octopus\OctopusServer\Instances" -filter "*.config"
+
+    $ConfigPaths = @()
+
+    if($null -ne $files)
+    {
+        $files | ForEach-Object {
+            $Config = Get-Content $_.FullName | ConvertFrom-Json
+            $ConfigPaths += $Config.ConfigurationFilePath
+        }
+    }
+
+    if( (Test-Path "HKLM:\SOFTWARE\Octopus\OctopusServer\"))
+    {
+        Get-ChildItem  "HKLM:\SOFTWARE\Octopus\OctopusServer\" | ForEach-Object {
+            $_ | ForEach-Object {
+                $ConfigPaths += Get-ItemProperty $_.PSPath | select -expand Configurationfilepath
+            }
+        }
+    }
+
+    if( (Test-Path "HKLM:\SOFTWARE\Octopus\Tentacle\" ) )
+    {
+        Get-ChildItem  "HKLM:\SOFTWARE\Octopus\Tentacle\" | ForEach-Object {
+            Get-ChildItem $_ | ForEach-Object {
+                $ConfigPaths += Get-ItemProperty -Path $_.PSPath | select -expand Configurationfilepath
+            }
+        }
+    }
+    return $ConfigPaths | select -Unique
+}
+
+Function Get-LogPath
+{
+    param([string[]]$ConfigPaths)
+    $LogPaths = @()
+    $ConfigPaths| ForEach-Object {
+        $ConfigXML = [xml](Get-Content $_ )
+        $Homepath = $ConfigXML.SelectSingleNode('/octopus-settings/set[@key="Octopus.Home"]/text()').Value
+        $LogPath = "$Homepath\Logs"
+        $LogPaths += $LogPath
+    }
+    return $LogPaths
+}
+
+Write-Host "##teamcity[blockOpened name='Log Files']"
+
+Get-LogPath -ConfigPaths (Get-ConfigPath) | ForEach-Object {
+    Get-ChildItem $_ -filter "*.txt" | ForEach-Object {
+        $LogPath = $_.FullName
+        Write-Host "##teamcity[blockOpened name='Log File $($LogPath)']"
+        Get-Content $LogPath | Write-Host
+        Write-Host "##teamcity[blockClosed name='Log File $($LogPath)']"
+    }
+}
+
+Write-Host "##teamcity[blockClosed name='Log Files']"

--- a/build-hyperv.ps1
+++ b/build-hyperv.ps1
@@ -26,7 +26,7 @@ if($offline)   # if you want to use offline, then you need a v3 and a v4 install
   if(-not (Get-ChildItem .\Tests | Where-Object {$_.Name -like "Octopus.3.*.msi"}))
   {
     Write-Warning "To run tests offline, you will need a v3 installer in the .\Tests folder"
-    throw 
+    throw
   }
 
   [pscustomobject]@{
@@ -79,8 +79,8 @@ if ($result.FailedCount -gt 0) {
 }
 
 Write-Output "Running 'vagrant up --provider hyperv'"
-vagrant up --provider hyperv --no-destroy-on-error --debug | Tee-Object -FilePath vagrant.log  #   --debug
+vagrant up --provider hyperv --no-destroy-on-error | Tee-Object -FilePath vagrant.log  #   --debug
 
 Write-Output "Dont forget to run 'vagrant destroy -f' when you have finished"
 
-stop-transcript 
+stop-transcript

--- a/build-hyperv.ps1
+++ b/build-hyperv.ps1
@@ -3,6 +3,8 @@ param(
   [switch]$offline
 )
 
+. Tests/powershell-helpers.ps1
+
 Start-Transcript .\vagrant-hyperv.log -Append
 
 # remove psreadline as it interferes with the SMB password prompt
@@ -77,7 +79,7 @@ if ($result.FailedCount -gt 0) {
 }
 
 Write-Output "Running 'vagrant up --provider hyperv'"
-vagrant up --provider hyperv --no-destroy-on-error | Tee-Object -FilePath vagrant.log  #   --debug
+vagrant up --provider hyperv --no-destroy-on-error --debug | Tee-Object -FilePath vagrant.log  #   --debug
 
 Write-Output "Dont forget to run 'vagrant destroy -f' when you have finished"
 

--- a/vagrantfile
+++ b/vagrantfile
@@ -28,8 +28,8 @@ def run_octopus_scenario(config, scenario, configuration_params = nil)
     dsc.abort_on_dsc_failure = true
     dsc.configuration_params = configuration_params unless configuration_params.nil?
   end
-  config.vm.provision "shell", path: "Tests/surface-logs.ps1"
   config.vm.provision "shell", inline: "write-output \"##teamcity[blockClosed name='Running Scenario #{scenario}']\""
+  config.vm.provision "shell", path: "Tests/surface-logs.ps1"
   config.vm.provision "shell", inline: $run_test_scenario_script.gsub('{scenario_name}', scenario.downcase)
 end
 
@@ -42,8 +42,8 @@ def run_tentacle_scenario(config, scenario, configuration_params = nil)
     dsc.abort_on_dsc_failure = true
     dsc.configuration_params = configuration_params unless configuration_params.nil?
   end
-  config.vm.provision "shell", path: "Tests/surface-logs.ps1"
   config.vm.provision "shell", inline: "write-output \"##teamcity[blockClosed name='Running Scenario #{scenario}']\""
+  config.vm.provision "shell", path: "Tests/surface-logs.ps1"
 end
 
 Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
@@ -79,7 +79,6 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
     config.vm.provider "hyperv" do |v, override|
       override.vm.box = "gusztavvargadr/w16s-sql17d"   # temporary box url. We'll need to build one eventually
       config.vm.network "public_network", bridge: "External Connection"
-      # override.vm.synced_folder ".", "/vagrant", type: "smb", smb_host: "192.168.1.3" # this is required or it guesses the wrong IP
       override.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
       override.vm.network :forwarded_port, guest: 80,   host: 8000, id: "web"
       override.vm.network :forwarded_port, guest: 443, host: 8443,  id: "ssl"

--- a/vagrantfile
+++ b/vagrantfile
@@ -28,6 +28,7 @@ def run_octopus_scenario(config, scenario, configuration_params = nil)
     dsc.abort_on_dsc_failure = true
     dsc.configuration_params = configuration_params unless configuration_params.nil?
   end
+  config.vm.provision "shell", path: "Tests/surface-logs.ps1"
   config.vm.provision "shell", inline: "write-output \"##teamcity[blockClosed name='Running Scenario #{scenario}']\""
   config.vm.provision "shell", inline: $run_test_scenario_script.gsub('{scenario_name}', scenario.downcase)
 end
@@ -41,6 +42,7 @@ def run_tentacle_scenario(config, scenario, configuration_params = nil)
     dsc.abort_on_dsc_failure = true
     dsc.configuration_params = configuration_params unless configuration_params.nil?
   end
+  config.vm.provision "shell", path: "Tests/surface-logs.ps1"
   config.vm.provision "shell", inline: "write-output \"##teamcity[blockClosed name='Running Scenario #{scenario}']\""
 end
 
@@ -77,7 +79,7 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
     config.vm.provider "hyperv" do |v, override|
       override.vm.box = "gusztavvargadr/w16s-sql17d"   # temporary box url. We'll need to build one eventually
       config.vm.network "public_network", bridge: "External Connection"
-      override.vm.synced_folder ".", "/vagrant", type: "smb", smb_host: "192.168.1.3" # this is required or it guesses the wrong IP
+      # override.vm.synced_folder ".", "/vagrant", type: "smb", smb_host: "192.168.1.3" # this is required or it guesses the wrong IP
       override.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
       override.vm.network :forwarded_port, guest: 80,   host: 8000, id: "web"
       override.vm.network :forwarded_port, guest: 443, host: 8443,  id: "ssl"


### PR DESCRIPTION
Picks up and surfaces Octopus Logs from the vagrant box's disk, allowing us to have a spelunk in there without logging on to the box

Logs surface in Team City under the "Scenario_xx_Install" block, in a sub-block entitled "Logfiles".

Example build log:

![image](https://user-images.githubusercontent.com/9834169/53713801-45e78100-3ea0-11e9-8209-e3d0dec000d1.png)
