### PR TITLE
Fixes for several back-compat issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Version 3.0 of OctopusDSC supports Octopus Deploy 4.x with backwards compatibili
 2. Install DSC module via `PowerShellGet\Install-Module -Name OctopusDSC`
 
 ### Manual ###
-1. Download the [latest release](https://github.com/OctopusDeploy/OctopusDSC/releases) 
+1. Download the [latest release](https://github.com/OctopusDeploy/OctopusDSC/releases)
 2. If required, unblock the zip file
 3. Extract the zip file to a folder called OctopusDSC under your modules folder (usually `%USERPROFILE%\Documents\WindowsPowerShell\Modules`)
 4. To confirm it's installed correctly, in a new powershell session run `Get-Module -ListAvailable -Name OctopusDSC`
@@ -38,7 +38,7 @@ This project is setup to use [Vagrant](vagrant.io) to provide a dev/test environ
 
 There are four options provided:
 
- - [build-aws.ps1](build-aws.ps1) 
+ - [build-aws.ps1](build-aws.ps1)
  - [build-azure.ps1](build-azure.ps1)
  - [build-hyperv-ps1](build-hyperv-ps1) - windows virtualisation (new)
  - [build-virtualbox.ps1](build-virtualbox.ps1) - cross-platform virtualisation
@@ -49,17 +49,17 @@ Configuration is handled by environment variables. The shell scripts will show a
 
 To run just the scenarios locally, follow these steps:
 
-1. Install Vagrant from [vagrantup.com](https://vagrantup.com)
+1. Install Vagrant from [vagrantup.com](https://vagrantup.com). (Note: version after 2.2.3 have altered WinRM upload behaviour which may cause issues)
 2. Install VirtualBox from [virtualbox.org](https://virtualbox.org) or Hyper-V (`Install-WindowsFeature –Name Hyper-V -IncludeManagementTools -Restart`  )
 3. _**If you are on a Mac or Linux**_ you need to install PowerShell, see https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md.
 4. If you want to test locally using virtualbox
     - Run `vagrant plugin install vagrant-dsc`
     - Run `vagrant plugin install vagrant-winrm-syncedfolders`
-    - Run `vagrant up -- provider virtualbox`. This will run all the scenarios under the [Tests](Tests) folder.
+    - Run `build-virtualbox.ps1`. This will run all the scenarios under the [Tests](Tests) folder.
 5. If you want to test locally using Hyper-V
     - Run `vagrant plugin install vagrant-dsc`
     - Run `vagrant plugin install vagrant-winrm-syncedfolders`
-    - Run `vagrant up -- provider hyperv`. This will run all the scenarios under the [Tests](Tests) folder.
+    - Run `build-hyperv.ps1`. This will run all the scenarios under the [Tests](Tests) folder.
 6. If you want to test using AWS
     - Run `vagrant plugin install vagrant-aws`
     - Run `vagrant plugin install vagrant-aws-winrm`
@@ -67,7 +67,7 @@ To run just the scenarios locally, follow these steps:
     - Set an environment variable `AWS_SECRET_ACCESS_KEY` to a valid value
     - Set an environment variable `AWS_SUBNET_ID` to a valid subnet where you want the instance launched
     - Set an environment variable `AWS_SECURITY_GROUP_ID` to a valid security group you want to assign to the instance
-    - Run `vagrant up --provider aws`. This will run all the scenarios under the [Tests](Tests) folder.
+    - Run `build-aws.ps1`. This will run all the scenarios under the [Tests](Tests) folder.
 7. If you want to test using Azure
     - Run `vagrant plugin install vagrant-azure`
     - Set an environment variable `AZURE_VM_PASSWORD` to a valid value
@@ -75,8 +75,8 @@ To run just the scenarios locally, follow these steps:
     - Set an environment variable `AZURE_TENANT_ID` to a valid value
     - Set an environment variable `AZURE_CLIENT_ID` to a valid value
     - Srt an environment variable `AZURE_CLIENT_SECRET` to a valid value
-    - Run `vagrant up --provider azure`. This will run all the scenarios under the [Tests](Tests) folder.
-8. Run `vagrant destroy -f` once you have finished to kill the virtual machine.
+    - Run `build-azure.ps1`. This will run all the scenarios under the [Tests](Tests) folder.
+8. Run `vagrant destroy -f` or the appropriate `cleanup-*.ps1` once you have finished to kill the virtual machine.
 
 Tests are written in [ServerSpec](serverspec.org), which is an infrastructure oriented layer over [RSpec](rspec.info).
 

--- a/Tests/Scenarios/Tentacle_Scenario_01_Install.ps1
+++ b/Tests/Scenarios/Tentacle_Scenario_01_Install.ps1
@@ -42,7 +42,7 @@ Configuration Tentacle_Scenario_01_Install
             Tenants = "John"
             TenantTags = "Hosting/Cloud"
 
-            # Policy = "Test Policy"
+            Policy = "Test Policy"
         }
 
         cOctopusSeqLogger "Enable logging to seq"

--- a/Tests/Scenarios/Tentacle_Scenario_01_Install.ps1
+++ b/Tests/Scenarios/Tentacle_Scenario_01_Install.ps1
@@ -42,7 +42,7 @@ Configuration Tentacle_Scenario_01_Install
             Tenants = "John"
             TenantTags = "Hosting/Cloud"
 
-            Policy = "Test Policy"
+            # Policy = "Test Policy"
         }
 
         cOctopusSeqLogger "Enable logging to seq"

--- a/Tests/Scenarios/Tentacle_Scenario_03_Reinstall.ps1
+++ b/Tests/Scenarios/Tentacle_Scenario_03_Reinstall.ps1
@@ -31,8 +31,8 @@ Configuration Tentacle_Scenario_03_Reinstall
             # Optional settings
             ListenPort = 10933;
             DefaultApplicationDirectory = "C:\Applications"
-            TentacleDownloadUrl = "https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.3.24.msi"
-            TentacleDownloadUrl64 = "https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.3.24-x64.msi"
+            TentacleDownloadUrl = "https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.20.0.msi"
+            TentacleDownloadUrl64 = "https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.20.0-x64.msi"
             PublicHostNameConfiguration = "ComputerName"
             TentacleHomeDirectory = "C:\Octopus\OctopusTentacleHome"
         }

--- a/Tests/Spec/tentacle_scenario_03_reinstall_spec.rb
+++ b/Tests/Spec/tentacle_scenario_03_reinstall_spec.rb
@@ -10,7 +10,7 @@ end
 
 describe file('C:/Program Files/Octopus Deploy/Tentacle/Tentacle.exe') do
   it { should be_file }
-  it { should have_version('3.20.0') }
+  it { should have_version('3.20.0.0') }
 end
 
 describe service('OctopusDeploy Tentacle') do

--- a/Tests/Spec/tentacle_scenario_03_reinstall_spec.rb
+++ b/Tests/Spec/tentacle_scenario_03_reinstall_spec.rb
@@ -10,7 +10,7 @@ end
 
 describe file('C:/Program Files/Octopus Deploy/Tentacle/Tentacle.exe') do
   it { should be_file }
-  it { should have_version('3.3.24.0') }
+  it { should have_version('3.20.0') }
 end
 
 describe service('OctopusDeploy Tentacle') do

--- a/Tests/configure-octopus-for-tentacle-tests.ps1
+++ b/Tests/configure-octopus-for-tentacle-tests.ps1
@@ -85,7 +85,7 @@ try
     $tenantEditor.Save() | Out-Null
 
     # create a non-default Test Machine Policy w/ defaults
-    $policyResource = new-object Octopus.Client.Model.MachinePolicyResource
+    $policyResource = $repository.MachinePolicies.GetTemplate()
     $policyResource.Name = "Test Policy"
     $policyResource.IsDefault = $false
     $policyResource.Description = "Test Machine Policy"

--- a/Tests/powershell-helpers.ps1
+++ b/Tests/powershell-helpers.ps1
@@ -41,8 +41,10 @@ function Test-PowershellModuleInstalled($moduleName) {
   }
 }
 
-function Test-CustomVersionOfVagrantDscPluginIsInstalled() {
-  $path = Resolve-Path ~/.vagrant.d/gems/*/gems/vagrant-dsc-*/lib/vagrant-dsc/provisioner.rb
+function Test-CustomVersionOfVagrantDscPluginIsInstalled() {  # does not deal well with machines that have two vesioned folders under /gems/
+  $path = Resolve-Path ~/.vagrant.d/gems/*/gems/vagrant-dsc-*/lib/vagrant-dsc/provisioner.rb |
+            Sort-Object -descending |
+            Select-Object -first 1 # sort and select to cope with multiple gem folders (upgraded vagrant)
 
   if (Test-Path $path) {
     $content = Get-Content $path -raw

--- a/build-aws.ps1
+++ b/build-aws.ps1
@@ -1,4 +1,5 @@
 #!/usr/local/bin/pwsh
+param([switch]$SkipPester)
 
 . Tests/powershell-helpers.ps1
 
@@ -24,18 +25,21 @@ Test-PluginInstalled "vagrant-aws-winrm"
 Test-CustomVersionOfVagrantDscPluginIsInstalled
 Test-PluginInstalled "vagrant-winrm-syncedfolders"
 
-Write-Output "##teamcity[blockOpened name='Pester tests']"
-Write-Output "Importing Pester module"
-Test-PowershellModuleInstalled "Pester"
-Test-PowershellModuleInstalled "PSScriptAnalyzer"
-Import-Module Pester -verbose -force
+if(-not $SkipPester)
+{
+  Write-Output "##teamcity[blockOpened name='Pester tests']"
+  Write-Output "Importing Pester module"
+  Test-PowershellModuleInstalled "Pester"
+  Test-PowershellModuleInstalled "PSScriptAnalyzer"
+  Import-Module Pester -verbose -force
 
-Write-Output "Running Pester Tests"
-$result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
-if ($result.FailedCount -gt 0) {
-  exit 1
+  Write-Output "Running Pester Tests"
+  $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
+  if ($result.FailedCount -gt 0) {
+    exit 1
+  }
+  Write-Output "##teamcity[blockClosed name='Pester tests']"
 }
-Write-Output "##teamcity[blockClosed name='Pester tests']"
 
 $randomGuid=[guid]::NewGuid()
 $keyName = "vagrant_$randomGuid"

--- a/build-hyperv.ps1
+++ b/build-hyperv.ps1
@@ -1,6 +1,7 @@
 #!/usr/local/bin/pwsh
 param(
-  [switch]$offline
+  [switch]$offline,
+  [switch]$SkipPester
 )
 
 . Tests/powershell-helpers.ps1
@@ -72,10 +73,13 @@ Write-Output "External virtual switch detected - good."
 Test-CustomVersionOfVagrantDscPluginIsInstalled
 Test-PluginInstalled "vagrant-winrm-syncedfolders"
 
-Write-Output "Running Pester Tests"
-$result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
-if ($result.FailedCount -gt 0) {
-  exit 1
+if(-not $SkipPester)
+{
+  Write-Output "Running Pester Tests"
+  $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
+  if ($result.FailedCount -gt 0) {
+    exit 1
+  }
 }
 
 Write-Output "Running 'vagrant up --provider hyperv'"

--- a/vagrantfile
+++ b/vagrantfile
@@ -81,6 +81,7 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
       config.vm.network "public_network", bridge: "External Connection"
       v.memory = 4096
       v.maxmemory = 4096
+      v.cpus = 2
       override.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
       override.vm.network :forwarded_port, guest: 80,   host: 8000, id: "web"
       override.vm.network :forwarded_port, guest: 443, host: 8443,  id: "ssl"
@@ -141,7 +142,7 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
   config.vm.provision "shell", path: "Tests/configure-dsc-local-configuration-manager.ps1"
 
   # Run DSC to install server
-  #run_octopus_scenario(config, 'Server_Scenario_01_Install')
+  run_octopus_scenario(config, 'Server_Scenario_01_Install')
 
   # Run DSC to install second HA node
   #run_octopus_scenario(config, 'Server_Scenario_02_Install_Second_Node')
@@ -180,10 +181,10 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
   #run_octopus_scenario(config, 'Server_Scenario_13_Remove')
 
   # install only without configure
-  run_octopus_scenario(config, 'Server_Scenario_14_Install_Without_Configure')
+  #run_octopus_scenario(config, 'Server_Scenario_14_Install_Without_Configure')
 
   # go from installed to configured
-  run_octopus_scenario(config, 'Server_Scenario_15_Configure_Preinstalled_Instance')
+  #run_octopus_scenario(config, 'Server_Scenario_15_Configure_Preinstalled_Instance')
 
   config.vm.provision "shell", path: "Tests/configure-octopus-for-tentacle-tests.ps1"
 

--- a/vagrantfile
+++ b/vagrantfile
@@ -24,7 +24,7 @@ def run_octopus_scenario(config, scenario, configuration_params = nil)
   config.vm.provision "dsc" do |dsc|
     dsc.configuration_file  = "#{scenario}.ps1"
     dsc.configuration_data_file  = "Tests/Scenarios/Configuration.psd1"
-    dsc.manifests_path = "Tests/Scenarios"
+    dsc.manifests_path = "Tests/Scenarios/"
     dsc.abort_on_dsc_failure = true
     dsc.configuration_params = configuration_params unless configuration_params.nil?
   end
@@ -38,7 +38,7 @@ def run_tentacle_scenario(config, scenario, configuration_params = nil)
   config.vm.provision "dsc" do |dsc|
     dsc.configuration_file  = "#{scenario}.ps1"
     dsc.configuration_data_file  = "Tests/Scenarios/Configuration.psd1"
-    dsc.manifests_path = "Tests/Scenarios"
+    dsc.manifests_path = "Tests/Scenarios/"
     dsc.abort_on_dsc_failure = true
     dsc.configuration_params = configuration_params unless configuration_params.nil?
   end
@@ -145,46 +145,46 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
   run_octopus_scenario(config, 'Server_Scenario_01_Install')
 
   # Run DSC to install second HA node
-  #run_octopus_scenario(config, 'Server_Scenario_02_Install_Second_Node')
+  run_octopus_scenario(config, 'Server_Scenario_02_Install_Second_Node')
 
   # remove the first node
-  #run_octopus_scenario(config, 'Server_Scenario_03_Remove')
+  run_octopus_scenario(config, 'Server_Scenario_03_Remove')
 
   # remove the second ode
-  #run_octopus_scenario(config, 'Server_Scenario_04_Remove_Second_Node')
+  run_octopus_scenario(config, 'Server_Scenario_04_Remove_Second_Node')
 
   # Run DSC to install server with a custom instance name
-  #run_octopus_scenario(config, 'Server_Scenario_05_Install_Custom_Instance')
+  run_octopus_scenario(config, 'Server_Scenario_05_Install_Custom_Instance')
 
   # remove the server with a custom instance name
-  #run_octopus_scenario(config, 'Server_Scenario_06_Remove_Custom_Instance')
+  run_octopus_scenario(config, 'Server_Scenario_06_Remove_Custom_Instance')
 
   # re-install old version
-  #run_octopus_scenario(config, 'Server_Scenario_07_Reinstall')
+  run_octopus_scenario(config, 'Server_Scenario_07_Reinstall')
 
   # upgrade to the latest
-  #run_octopus_scenario(config, 'Server_Scenario_08_Upgrade', { "-ApiKey" => "$ENV:OctopusApiKey" })
+  run_octopus_scenario(config, 'Server_Scenario_08_Upgrade', { "-ApiKey" => "$ENV:OctopusApiKey" })
 
   # install watchdog
-  #run_octopus_scenario(config, 'Server_Scenario_09_Watchdog_Create')
+  run_octopus_scenario(config, 'Server_Scenario_09_Watchdog_Create')
 
   # delete watchdog
-  #run_octopus_scenario(config, 'Server_Scenario_10_Watchdog_Delete')
+  run_octopus_scenario(config, 'Server_Scenario_10_Watchdog_Delete')
 
   # remove again prior to installing 4
-  #run_octopus_scenario(config, 'Server_Scenario_11_Remove')
+  run_octopus_scenario(config, 'Server_Scenario_11_Remove')
 
   # install v4
-  #run_octopus_scenario(config, 'Server_Scenario_12_Built_In_Worker')
+  run_octopus_scenario(config, 'Server_Scenario_12_Built_In_Worker')
 
   # remove again prior to testing "install only"
-  #run_octopus_scenario(config, 'Server_Scenario_13_Remove')
+  run_octopus_scenario(config, 'Server_Scenario_13_Remove')
 
   # install only without configure
-  #run_octopus_scenario(config, 'Server_Scenario_14_Install_Without_Configure')
+  run_octopus_scenario(config, 'Server_Scenario_14_Install_Without_Configure')
 
   # go from installed to configured
-  #run_octopus_scenario(config, 'Server_Scenario_15_Configure_Preinstalled_Instance')
+  run_octopus_scenario(config, 'Server_Scenario_15_Configure_Preinstalled_Instance')
 
   config.vm.provision "shell", path: "Tests/configure-octopus-for-tentacle-tests.ps1"
 

--- a/vagrantfile
+++ b/vagrantfile
@@ -79,6 +79,8 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
     config.vm.provider "hyperv" do |v, override|
       override.vm.box = "gusztavvargadr/w16s-sql17d"   # temporary box url. We'll need to build one eventually
       config.vm.network "public_network", bridge: "External Connection"
+      v.memory = 4096
+      v.maxmemory = 4096
       override.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
       override.vm.network :forwarded_port, guest: 80,   host: 8000, id: "web"
       override.vm.network :forwarded_port, guest: 443, host: 8443,  id: "ssl"
@@ -139,43 +141,43 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
   config.vm.provision "shell", path: "Tests/configure-dsc-local-configuration-manager.ps1"
 
   # Run DSC to install server
-  run_octopus_scenario(config, 'Server_Scenario_01_Install')
+  #run_octopus_scenario(config, 'Server_Scenario_01_Install')
 
   # Run DSC to install second HA node
-  run_octopus_scenario(config, 'Server_Scenario_02_Install_Second_Node')
+  #run_octopus_scenario(config, 'Server_Scenario_02_Install_Second_Node')
 
   # remove the first node
-  run_octopus_scenario(config, 'Server_Scenario_03_Remove')
+  #run_octopus_scenario(config, 'Server_Scenario_03_Remove')
 
   # remove the second ode
-  run_octopus_scenario(config, 'Server_Scenario_04_Remove_Second_Node')
+  #run_octopus_scenario(config, 'Server_Scenario_04_Remove_Second_Node')
 
   # Run DSC to install server with a custom instance name
-  run_octopus_scenario(config, 'Server_Scenario_05_Install_Custom_Instance')
+  #run_octopus_scenario(config, 'Server_Scenario_05_Install_Custom_Instance')
 
   # remove the server with a custom instance name
-  run_octopus_scenario(config, 'Server_Scenario_06_Remove_Custom_Instance')
+  #run_octopus_scenario(config, 'Server_Scenario_06_Remove_Custom_Instance')
 
   # re-install old version
-  run_octopus_scenario(config, 'Server_Scenario_07_Reinstall')
+  #run_octopus_scenario(config, 'Server_Scenario_07_Reinstall')
 
   # upgrade to the latest
-  run_octopus_scenario(config, 'Server_Scenario_08_Upgrade', { "-ApiKey" => "$ENV:OctopusApiKey" })
+  #run_octopus_scenario(config, 'Server_Scenario_08_Upgrade', { "-ApiKey" => "$ENV:OctopusApiKey" })
 
   # install watchdog
-  run_octopus_scenario(config, 'Server_Scenario_09_Watchdog_Create')
+  #run_octopus_scenario(config, 'Server_Scenario_09_Watchdog_Create')
 
   # delete watchdog
-  run_octopus_scenario(config, 'Server_Scenario_10_Watchdog_Delete')
+  #run_octopus_scenario(config, 'Server_Scenario_10_Watchdog_Delete')
 
   # remove again prior to installing 4
-  run_octopus_scenario(config, 'Server_Scenario_11_Remove')
+  #run_octopus_scenario(config, 'Server_Scenario_11_Remove')
 
   # install v4
-  run_octopus_scenario(config, 'Server_Scenario_12_Built_In_Worker')
+  #run_octopus_scenario(config, 'Server_Scenario_12_Built_In_Worker')
 
   # remove again prior to testing "install only"
-  run_octopus_scenario(config, 'Server_Scenario_13_Remove')
+  #run_octopus_scenario(config, 'Server_Scenario_13_Remove')
 
   # install only without configure
   run_octopus_scenario(config, 'Server_Scenario_14_Install_Without_Configure')


### PR DESCRIPTION
1. vagrant 2.4.4 breaks the WinRM upload method on the tests. Note added.
2. tentacle registration of 3.2.24 onto a Spaces-enabled server fail with `Octopus.Client.Exceptions.OctopusMethodNotAllowedFoundException` in scenario 03. 
3. Fixed registration error in tentacle tests by basing customer policy on a template
4. `Error converting value "TaskViewLog" to type 'Octopus.Core.Resources.Permission'` when upgrading server in scenario 08
5. If machine running tests had multiple gem directories, test may fail to detect the custom vagrant-dsc plugin
6. Some small tweaks to try and tighten feedback loops while running locally in hyper-v.