### PR TITLE
refactor the invalid-json change (move into shared code)

### DIFF
--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
@@ -236,22 +236,7 @@ function Import-ServerConfig {
     }
 
     if (Test-OctopusVersionSupportsShowConfiguration) {
-        $rawConfig = & $octopusServerExePath show-configuration --format=json-hierarchical --noconsolelogging --console --instance $InstanceName | out-string
-
-        # handle a specific error where an exception in registry migration finds its way into the json-hierarchical output
-        # Refer to Issue #179 (https://github.com/OctopusDeploy/OctopusDSC/issues/179)
-
-        if(Test-ValidJson $rawConfig) {
-            $config = $rawConfig | ConvertFrom-Json
-        } else {
-            Write-Warning "Invalid json encountered in show-configuration; attempting to clean up."
-            $cleanedUpConfig = Get-CleanedJson $rawConfig
-            if(Test-ValidJson $cleanedUpConfig ) {
-                $config = $cleanedUpConfig | ConvertFrom-Json
-            } else {
-                Write-Error "Attempted to cleanup bad JSON and failed."
-            }
-        }
+        $config = Get-ServerConfiguration $InstanceName
 
         # show-configuration only added support for the license from 4.1.3
         # unfortunately, $null implies that its the free license, so it would trigger a change every time DSC runs

--- a/Tests/Scenarios/Server_Scenario_08_Upgrade.ps1
+++ b/Tests/Scenarios/Server_Scenario_08_Upgrade.ps1
@@ -8,7 +8,7 @@ Configuration Server_Scenario_08_Upgrade
     $pass = ConvertTo-SecureString "SuperS3cretPassw0rd!" -AsPlainText -Force
     $cred = New-Object System.Management.Automation.PSCredential ("OctoAdmin", $pass)
 
-    $pass = ConvertTo-SecureString $ApiKey -AsPlainText -Force
+    $pass = ConvertTo-SecureString $ENV:OctopusApiKey -AsPlainText -Force
     $apiCred = New-Object System.Management.Automation.PSCredential ("ignored", $pass)
 
     Node "localhost"

--- a/vagrantfile
+++ b/vagrantfile
@@ -96,7 +96,7 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
     aws.access_key_id = aws_access_key_id
     aws.secret_access_key = aws_secret_access_key
     aws.region = "ap-southeast-2"
-    aws.instance_type = "c4.large"
+    aws.instance_type = "c4.xlarge"
     aws.keypair_name = "#{aws_key_name}"
     aws.tags = {
       'Name' => 'Vagrant DSC testing'

--- a/vagrantfile
+++ b/vagrantfile
@@ -108,6 +108,7 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
     override.vm.box = "OctopusDeploy/dsc-test-server-windows-server-1803" #box added via launcher script
     override.ssh.private_key_path = "./#{aws_key_name}.pem"
     override.winrm.username = "Administrator"
+    override.winrm.timeout = 180
     override.winrm.password = :aws # this uses the vagrant-aws-winrm plugin to get the password from aws
     override.winrm.transport = :ssl
     override.winrm.port = 5986


### PR DESCRIPTION
The previous invalid "json" fix was only in `cOctopusServer`, however there's also an implementation in other resources. The problem resurfaced in a transient way in `cOctopusServerUsernamePasswordAuthentication` today, so I've shifted the fix to shared code so we can catch any future occurrences