### PR TITLE
Fix #202, couple of other tiny problems.

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -926,9 +926,6 @@ function Remove-WorkerPoolRegistration
             "--console"
         )
 
-        # Set the location
-        Push-Location -Path $tentacleDir
-
         # Determine which authentication mechanism ot use
         if (![string]::IsNullOrEmpty($apiKey))
         {
@@ -952,7 +949,7 @@ function Remove-WorkerPoolRegistration
         }
 
         # Execute teh process
-        Invoke-AndAssert {&.\tentacle.exe ($argumentList)}
+        Invoke-AndAssert { & $tentacleDir\tentacle.exe ($argumentList)}
     }
     else
     {
@@ -1034,11 +1031,8 @@ function Add-TentacleToWorkerPool
             )
         }
 
-        # Set the location
-        Push-Location -Path $tentacleDir
-
         # Execute the process
-        Invoke-AndAssert { &.\tentacle.exe ($argumentList)}
+        Invoke-AndAssert { & $tentacleDir\tentacle.exe ($argumentList)}
     }
 }
 

--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -757,25 +757,25 @@ function New-Tentacle {
 
     Write-Verbose "Configuring and registering Tentacle"
 
-    Push-Location "${env:ProgramFiles}\Octopus Deploy\Tentacle"
+    $tentacleDir = "${env:ProgramFiles}\Octopus Deploy\Tentacle"
 
     $tentacleAppDirectory = $DefaultApplicationDirectory
     $tentacleConfigFile = "$tentacleHomeDirectory\$Name\Tentacle.config"
     Write-Verbose "Tentacle configuration set as $tentacleConfigFile"
-    Invoke-AndAssert { & .\tentacle.exe create-instance --instance $name --config "$tentacleConfigFile" --console }
-    Invoke-AndAssert { & .\tentacle.exe configure --instance $name --home "$tentacleHomeDirectory" --console }
-    Invoke-AndAssert { & .\tentacle.exe configure --instance $name --app "$tentacleAppDirectory" --console }
-    Invoke-AndAssert { & .\tentacle.exe new-certificate --instance $name --console }
+    Invoke-AndAssert { & $tentacleDir\tentacle.exe create-instance --instance $name --config "$tentacleConfigFile" --console }
+    Invoke-AndAssert { & $tentacleDir\tentacle.exe configure --instance $name --home "$tentacleHomeDirectory" --console }
+    Invoke-AndAssert { & $tentacleDir\tentacle.exe configure --instance $name --app "$tentacleAppDirectory" --console }
+    Invoke-AndAssert { & $tentacleDir\tentacle.exe new-certificate --instance $name --console }
 
     if (($null -ne $octopusServerThumbprint) -and ($octopusServerThumbprint -ne "")) {
-        Invoke-AndAssert { & .\tentacle.exe configure --instance $name --trust $octopusServerThumbprint --console }
+        Invoke-AndAssert { & $tentacleDir\tentacle.exe configure --instance $name --trust $octopusServerThumbprint --console }
     }
 
     if ($CommunicationMode -eq "Listen") {
-        Invoke-AndAssert { & .\tentacle.exe configure --instance $name --port $port --console }
+        Invoke-AndAssert { & $tentacleDir\tentacle.exe configure --instance $name --port $port --console }
     }
     else {
-        Invoke-AndAssert { & .\tentacle.exe configure --instance $name --port $port --noListen "True" --console }
+        Invoke-AndAssert { & $tentacleDir\tentacle.exe configure --instance $name --port $port --noListen "True" --console }
     }
 
     $serviceArgs = @(
@@ -795,7 +795,7 @@ function New-Tentacle {
         )
     }
 
-    Invoke-AndAssert { & .\tentacle.exe ($serviceArgs) }
+    Invoke-AndAssert { & $tentacleDir\tentacle.exe ($serviceArgs) }
 
     # Reset location
     Pop-Location
@@ -803,7 +803,7 @@ function New-Tentacle {
     if ($registerWithServer) {
 
         if (($null -ne $octopusServerThumbprint) -and ($octopusServerThumbprint -ne "")) {
-            Invoke-AndAssert { & .\tentacle.exe configure --instance $name --trust $octopusServerThumbprint --console }
+            Invoke-AndAssert { & $tentacleDir\tentacle.exe configure --instance $name --trust $octopusServerThumbprint --console }
         }
 
         # Register the tentacle
@@ -834,7 +834,7 @@ function New-Tentacle {
     else {
         Write-Verbose "Skipping registration with server as 'RegisterWithServer' is set to '$registerWithServer'"
     }
-    Pop-Location
+
     Write-Verbose "Tentacle commands complete"
 }
 
@@ -887,9 +887,7 @@ function Remove-TentacleRegistration {
     if ((test-path $tentacleDir) -and (test-path "$tentacleDir\tentacle.exe")) {
         Write-Verbose "Beginning Tentacle deregistration"
         Write-Verbose "Tentacle commands complete"
-        Push-Location $tentacleDir
-        Invoke-AndAssert { & .\tentacle.exe deregister-from --instance "$name" --server $octopusServerUrl --apiKey $apiKey --console }
-        Pop-Location
+        Invoke-AndAssert { & $tentacleDir\tentacle.exe deregister-from --instance "$name" --server $octopusServerUrl --apiKey $apiKey --console }
     }
     else {
         Write-Verbose "Could not find Tentacle.exe"
@@ -1145,11 +1143,9 @@ function Register-Tentacle
     }
 
     # Set the location
-    Push-Location "${env:ProgramFiles}\Octopus Deploy\Tentacle"
+    $tentacleDir = "${env:ProgramFiles}\Octopus Deploy\Tentacle"
 
     Write-Verbose "Registering with arguments: $registerArguments"
-    Invoke-AndAssert { & .\tentacle.exe ($registerArguments) }
+    Invoke-AndAssert { & $tentacleDir\tentacle.exe ($registerArguments) }
 
-    # Reset location
-    Pop-Location
 }

--- a/Tests/powershell-helpers.ps1
+++ b/Tests/powershell-helpers.ps1
@@ -94,7 +94,7 @@ Function Invoke-VagrantWithRetries {
   }
 
   do {
-    Write-Output (@("Running Vagrant with arguments '", $args, "'") -join "")
+    Write-Output (@("Running Vagrant with arguments '", ($args -join " "), "'") -join "")
     vagrant $args  | Tee-Object -FilePath vagrant.log
     Write-Output "'vagrant up' exited with exit code $LASTEXITCODE"
     $attempts = $attempts + 1

--- a/build-virtualbox.ps1
+++ b/build-virtualbox.ps1
@@ -9,6 +9,8 @@ param(
   [switch]$debug
 )
 
+. Tests/powershell-helpers.ps1
+
 Start-Transcript .\vagrant-virtualbox.log
 
 Set-OctopusDscEnvVars @PSBoundParameters
@@ -37,7 +39,7 @@ if (!(Get-Command choco.exe -ErrorAction SilentlyContinue))
   Write-Output 'Please install Chocolatey.'
   exit 1
 }
-else 
+else
 {
   Write-Output "Chocolatey installed - good."
 }
@@ -60,7 +62,7 @@ else
   Write-Output "-SkipPester was specified, skipping pester tests"
 }
 
-$splat = {
+$splat = @{
   provider = 'virtualbox';
   retainondestroy = $retainondestroy.IsPresent;
   debug = $debug.IsPresent;


### PR DESCRIPTION
#202 is a reported problem with cTentacleAgent not being found in an `Invoke-AndAssert` block.

This changes to an absolute path on the call, so we can't accidentally hop into a different directory's context.