### PR TITLE
When using FQDN, get FQDN should include any domain prefix 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+.vs/
 
 # Build results
 [Dd]ebug/

--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -163,11 +163,11 @@ function Get-TargetResource {
         [ValidateSet("Untenanted","TenantedOrUntenanted","Tenanted")]
         [string]$TenantedDeploymentParticipation
     )
-
-    Test-ParameterSet   -publicHostNameConfiguration $PublicHostNameConfiguration `
+    
+	 Test-ParameterSet   -publicHostNameConfiguration $PublicHostNameConfiguration `
                         -customPublicHostName $CustomPublicHostName
-
-    Write-Verbose "Checking if Tentacle is installed"
+	
+	 Write-Verbose "Checking if Tentacle is installed"
     $installLocation = (Get-ItemProperty -path "HKLM:\Software\Octopus\Tentacle" -ErrorAction SilentlyContinue).InstallLocation
     $present = ($null -ne $installLocation)
     Write-Verbose "Tentacle present: $present"
@@ -872,8 +872,7 @@ function Get-PublicHostName {
         $publicHostName = $customPublicHostName
     }
     elseif ($publicHostNameConfiguration -eq "FQDN") {
-        $computer = Get-CimInstance win32_computersystem
-        $publicHostName = "$($computer.DNSHostName).$($computer.Domain)"
+        $publicHostName = [System.Net.Dns]::GetHostByName($env:computerName).HostName
     }
     elseif ($publicHostNameConfiguration -eq "ComputerName") {
         $publicHostName = $env:COMPUTERNAME


### PR DESCRIPTION
When using FQDN and using this on our corporate domain which contains many sub-domains, FQDN did not work.

If the VM FQDN is vm1.test.domain.com, the DSC was returning vm1.domain.com.

This is now fixed and is working for us.