### PR TITLE
Updating check and import of PowerShell modules

### DIFF
--- a/Tests/OctopusDSC.Tests.ps1
+++ b/Tests/OctopusDSC.Tests.ps1
@@ -1,5 +1,8 @@
+$path = Join-Path -Path $PSScriptRoot -ChildPath "powershell-helpers.ps1"
+. $path
+
 Describe "PSScriptAnalyzer" {
-    Import-Module PSScriptAnalyzer
+    Import-PowerShellModule -Name PSScriptAnalyzer -MinimumVersion "1.18.3"
     $excludedRules = @(
         'PSUseShouldProcessForStateChangingFunctions'
     )

--- a/Tests/powershell-helpers.ps1
+++ b/Tests/powershell-helpers.ps1
@@ -38,7 +38,6 @@ function Test-AppExists($appName) {
 }
 
 function Import-PowerShellModule ($Name, $MinimumVersion) {
-  
   $command = Get-Module $Name -listavailable
   if ($null -eq $command) {
     write-host "Please install $($Name): Install-Module -Name $Name -Force" -foregroundcolor red

--- a/Tests/powershell-helpers.ps1
+++ b/Tests/powershell-helpers.ps1
@@ -37,18 +37,28 @@ function Test-AppExists($appName) {
   return $null -ne $command
 }
 
-function Test-PowershellModuleInstalled($moduleName, $version) {
-  $command = Get-Module $moduleName -listavailable
+function Import-PowerShellModule ($Name, $MinimumVersion) {
+  
+  $command = Get-Module $Name -listavailable
   if ($null -eq $command) {
-    write-host "Please install $($moduleName): Install-Module -Name $moduleName -Force" -foregroundcolor red
+    write-host "Please install $($Name): Install-Module -Name $Name -Force" -foregroundcolor red
     exit 1
   }
-  if ($null -ne $version) {
-    if ($command.Version -lt [System.Version]::Parse($version)) {
-      write-host "Please install $($moduleName) $version or higher (you have version $($command.Version)): Update-Module -Name $moduleName -Force" -foregroundcolor red
+
+  if ($command.Count -gt 1) {
+    $command = $command | Sort-Object -Property Version -Descending | Select-Object -First 1
+  }
+
+
+  if ($null -ne $MinimumVersion) {
+    if ($command.Version -lt [System.Version]::Parse($MinimumVersion)) {
+      write-host "Please install $($Name) $MinimumVersion or higher (you have version $($command.Version)): Update-Module -Name $Name -Force" -foregroundcolor red
       exit 1
     }
   }
+
+  Write-Output "Importing module $Name with version $($command.Version)..."
+  Import-Module -Name $Name -Version $command.Version
 }
 
 function Test-CustomVersionOfVagrantDscPluginIsInstalled() {  # does not deal well with machines that have two versioned folders under /gems/

--- a/build-aws.ps1
+++ b/build-aws.ps1
@@ -43,9 +43,9 @@ Remove-OldLogsBeforeNewRun
 if(-not $SkipPester) {
   Write-Output "##teamcity[blockOpened name='Pester tests']"
   Write-Output "Importing Pester module"
-  Test-PowershellModuleInstalled "Pester" "4.9.0"
-  Test-PowershellModuleInstalled "PSScriptAnalyzer" "1.18.3"
-  Import-Module Pester -force
+  Import-PowerShellModule -Name "Pester" -MinimumVersion "4.9.0"
+  
+  
   Write-Output "Running Pester Tests"
   $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
   if ($result.FailedCount -gt 0) {

--- a/build-aws.ps1
+++ b/build-aws.ps1
@@ -45,7 +45,6 @@ if(-not $SkipPester) {
   Write-Output "Importing Pester module"
   Import-PowerShellModule -Name "Pester" -MinimumVersion "4.9.0"
   
-  
   Write-Output "Running Pester Tests"
   $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
   if ($result.FailedCount -gt 0) {

--- a/build-azure.ps1
+++ b/build-azure.ps1
@@ -42,9 +42,9 @@ Remove-OldLogsBeforeNewRun
 
 if(-not $SkipPester) {
     Write-Output "Importing Pester module"
-    Test-PowershellModuleInstalled "Pester" "4.9.0"
-    Test-PowershellModuleInstalled "PSScriptAnalyzer" "1.18.3"
-    Import-Module Pester -verbose -force
+    Import-PowerShellModule -Name "Pester" -MinimumVersion "4.9.0"
+    
+    
 
     Write-Output "Running Pester Tests"
     $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru

--- a/build-azure.ps1
+++ b/build-azure.ps1
@@ -44,7 +44,6 @@ if(-not $SkipPester) {
     Write-Output "Importing Pester module"
     Import-PowerShellModule -Name "Pester" -MinimumVersion "4.9.0"
     
-    
 
     Write-Output "Running Pester Tests"
     $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru

--- a/build-hyperv.ps1
+++ b/build-hyperv.ps1
@@ -56,10 +56,8 @@ Test-PluginInstalled "vagrant-winrm-file-download"
 Remove-OldLogsBeforeNewRun
 
 if(-not $SkipPester) {
-  Write-Output "Importing Pester module"
-  Test-PowershellModuleInstalled "Pester" "4.9.0"
-  Test-PowershellModuleInstalled "PSScriptAnalyzer" "1.18.3"
-  Import-Module Pester -force
+  Import-PowerShellModule -Name "Pester" -MinimumVersion "4.9.0"
+  
   Write-Output "Running Pester Tests"
   $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
   if ($result.FailedCount -gt 0) {

--- a/build-virtualbox.ps1
+++ b/build-virtualbox.ps1
@@ -10,12 +10,9 @@ param(
 )
 
 . Tests/powershell-helpers.ps1
-
 Start-Transcript .\vagrant-virtualbox.log
 
 Set-OctopusDscEnvVars @PSBoundParameters
-
-. Tests/powershell-helpers.ps1
 
 if (-not (Test-AppExists "vagrant")) {
   Write-Output "Please install vagrant from vagrantup.com."
@@ -37,9 +34,9 @@ Remove-OldLogsBeforeNewRun
 
 if(-not $SkipPester) {
   Write-Output "Importing Pester module"
-  Test-PowershellModuleInstalled "Pester" "4.9.0"
-  Test-PowershellModuleInstalled "PSScriptAnalyzer" "1.18.3"
-  Import-Module Pester -force
+  Import-PowerShellModule -Name "Pester" -MinimumVersion "4.9.0"
+  
+  
   Write-Output "Running Pester Tests"
   $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
   if ($result.FailedCount -gt 0) {

--- a/build-virtualbox.ps1
+++ b/build-virtualbox.ps1
@@ -36,7 +36,6 @@ if(-not $SkipPester) {
   Write-Output "Importing Pester module"
   Import-PowerShellModule -Name "Pester" -MinimumVersion "4.9.0"
   
-  
   Write-Output "Running Pester Tests"
   $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
   if ($result.FailedCount -gt 0) {


### PR DESCRIPTION
Newer versions of PowerShell allow for side-by-side installation of PowerShell module versions.  I've updated the code to compare the highest installed version against a minimum specified version.  If the installed is the same or higher, the module is imported.  If not, an error is thrown telling the user they must have at least the minimum specified version.