### PR TITLE
Only call the configure command once

### DIFF
--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/InstallOnly/ExpectedResult.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/InstallOnly/ExpectedResult.ps1
@@ -1,8 +1,6 @@
 return @(
     "create-instance --instance Tentacle --config C:\Octopus\Tentacle\Tentacle.config --console",
-    "configure --instance Tentacle --home C:\Octopus --console",
-    "configure --instance Tentacle --app C:\Applications --console",
     "new-certificate --instance Tentacle --console",
-    "configure --instance Tentacle --port 10933 --console",
+    "configure --instance Tentacle --home C:\Octopus --app C:\Applications --console --port 10933",
     "service --install --instance Tentacle --console --reconfigure"
 )

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/NewInstance/ExpectedResult.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/NewInstance/ExpectedResult.ps1
@@ -1,9 +1,7 @@
 return @(
   "create-instance --instance Tentacle --config C:\Octopus\Tentacle\Tentacle.config --console",
-  "configure --instance Tentacle --home C:\Octopus --console",
-  "configure --instance Tentacle --app C:\Applications --console",
   "new-certificate --instance Tentacle --console",
-  "configure --instance Tentacle --port 10935 --console",
+  "configure --instance Tentacle --home C:\Octopus --app C:\Applications --console --port 10935",
   "service --install --instance Tentacle --console --reconfigure --username Admin --password S3cur3P4ssphraseHere!",
   "register-with --instance Tentacle --server http://localhost:81 --name My Tentacle --apiKey API-1234 --force --console --comms-style TentaclePassive --publicHostName mytestserver.local --environment dev --environment prod --role web-server"
 )

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/NewInstanceInSpace/ExpectedResult.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/NewInstanceInSpace/ExpectedResult.ps1
@@ -1,9 +1,7 @@
 return @(
   "create-instance --instance Tentacle --config C:\Octopus\Tentacle\Tentacle.config --console",
-  "configure --instance Tentacle --home C:\Octopus --console",
-  "configure --instance Tentacle --app C:\Applications --console",
   "new-certificate --instance Tentacle --console",
-  "configure --instance Tentacle --port 10935 --console",
+  "configure --instance Tentacle --home C:\Octopus --app C:\Applications --console --port 10935",
   "service --install --instance Tentacle --console --reconfigure --username Admin --password S3cur3P4ssphraseHere!",
   "register-with --instance Tentacle --server http://localhost:81 --name My Tentacle --apiKey API-1234 --force --console --space My Space --comms-style TentaclePassive --publicHostName mytestserver.local --environment dev --environment prod --role web-server"
 )

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/NewPollingTentacle/CurrentState.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/NewPollingTentacle/CurrentState.ps1
@@ -1,0 +1,4 @@
+return @{
+  Ensure = "Absent";
+  State = "Stopped"
+}

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/NewPollingTentacle/ExpectedResult.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/NewPollingTentacle/ExpectedResult.ps1
@@ -1,0 +1,7 @@
+return @(
+  "create-instance --instance Tentacle --config C:\Octopus\Tentacle\Tentacle.config --console",
+  "new-certificate --instance Tentacle --console",
+  "configure --instance Tentacle --home C:\Octopus --app C:\Applications --console --noListen True",
+  "service --install --instance Tentacle --console --reconfigure --username Admin --password S3cur3P4ssphraseHere!",
+  "register-with --instance Tentacle --server http://localhost:81 --name My Tentacle --apiKey API-1234 --force --console --comms-style TentacleActive --server-comms-port 10943 --environment dev --environment prod --role web-server"
+)

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/NewPollingTentacle/RequestedState.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/NewPollingTentacle/RequestedState.ps1
@@ -1,0 +1,21 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')] # these are tests, not anything that needs to be secure
+param()
+
+$pass = ConvertTo-SecureString "S3cur3P4ssphraseHere!" -AsPlainText -Force
+$cred = New-Object System.Management.Automation.PSCredential ("Admin", $pass)
+
+return @{
+    Ensure = "Present";
+    State = "Started";
+    Name = "Tentacle";
+    DisplayName = "My Tentacle";
+    OctopusServerUrl = "http://localhost:81";
+    ApiKey = "API-1234";
+    Environments = @("dev", "prod");
+    Roles = "web-server";
+    CommunicationMode = "Poll"
+    ListenPort = 10935;
+    TentacleServiceCredential = $cred
+    DefaultApplicationDirectory = "C:\Applications"
+    TentacleHomeDirectory = "C:\Octopus"
+}

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/NewWorker/ExpectedResult.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/NewWorker/ExpectedResult.ps1
@@ -1,9 +1,7 @@
 return @(
     "create-instance --instance Tentacle --config C:\Octopus\Tentacle\Tentacle.config --console",
-    "configure --instance Tentacle --home C:\Octopus --console",
-    "configure --instance Tentacle --app C:\Applications --console",
     "new-certificate --instance Tentacle --console",
-    "configure --instance Tentacle --port 10935 --console",
+    "configure --instance Tentacle --home C:\Octopus --app C:\Applications --console --port 10935",
     "service --install --instance Tentacle --console --reconfigure --username Admin --password S3cur3P4ssphraseHere!",
     "register-worker --instance Tentacle --server http://localhost:81 --name My Worker --force --apiKey API-1234 --comms-style TentaclePassive --publicHostName mytestserver.local --workerpool NodeJSWorker"
 )

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/NewWorkerInSpace/ExpectedResult.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/NewWorkerInSpace/ExpectedResult.ps1
@@ -1,9 +1,7 @@
 return @(
     "create-instance --instance Tentacle --config C:\Octopus\Tentacle\Tentacle.config --console",
-    "configure --instance Tentacle --home C:\Octopus --console",
-    "configure --instance Tentacle --app C:\Applications --console",
     "new-certificate --instance Tentacle --console",
-    "configure --instance Tentacle --port 10935 --console",
+    "configure --instance Tentacle --home C:\Octopus --app C:\Applications --console --port 10935",
     "service --install --instance Tentacle --console --reconfigure --username Admin --password S3cur3P4ssphraseHere!",
     "register-worker --instance Tentacle --server http://localhost:81 --name My Worker --force --space My Space --apiKey API-1234 --comms-style TentaclePassive --publicHostName mytestserver.local --workerpool NodeJSWorker"
 )

--- a/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
@@ -318,6 +318,32 @@ try
                 }
             }
 
+            Context "New polling tentacle" {
+                Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
+                Mock Get-TargetResource { return Get-CurrentConfiguration "NewPollingTentacle" }
+                Mock Invoke-MsiExec {}
+                Mock Request-File {}
+                Mock Update-InstallState {}
+                Mock Invoke-AndAssert {}
+                Mock Start-Service {}
+                Mock Get-PublicHostName { return "mytestserver.local"; }
+                Mock New-Item {}
+
+                $params = Get-RequestedConfiguration "NewPollingTentacle"
+                Set-TargetResource @params
+
+                Assert-ExpectedResult "NewPollingTentacle"
+                it "Should download the MSI" {
+                    Assert-MockCalled Request-File
+                }
+                it "Should install the MSI" {
+                    Assert-MockCalled Invoke-MsiExec
+                }
+                it "Should start the service" {
+                    Assert-MockCalled Start-Service
+                }
+            }
+
             Context "New instance in space" {
                 Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
                 Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstanceInSpace" }


### PR DESCRIPTION
As a speed optimisation. It was calling it up to 4 times in some circumstances.
Also adds invocation tests for polling tentacles