### PR TITLE
Stop testing the cOctopusSeqLogger component temporarily

### DIFF
--- a/Tests/Scenarios/Server_Scenario_01_Install.ps1
+++ b/Tests/Scenarios/Server_Scenario_01_Install.ps1
@@ -1,9 +1,6 @@
 $pass = ConvertTo-SecureString "SuperS3cretPassw0rd!" -AsPlainText -Force
 $cred = New-Object System.Management.Automation.PSCredential ("OctoAdmin", $pass)
 
-$seqPlainTextApiKey = ConvertTo-SecureString "MyMagicSeqApiKey" -AsPlainText -Force
-$seqApiKey = New-Object System.Management.Automation.PSCredential ("ignored", $seqPlainTextApiKey)
-
 Configuration Server_Scenario_01_Install
 {
     Import-DscResource -ModuleName OctopusDSC
@@ -44,16 +41,6 @@ Configuration Server_Scenario_01_Install
 
             LogTaskMetrics = $true
             LogRequestMetrics = $false
-        }
-
-        cOctopusSeqLogger "Enable logging to seq"
-        {
-            InstanceType = "OctopusServer"
-            Ensure = "Present"
-            SeqServer = "http://localhost/seq"
-            SeqApiKey = $seqApiKey
-            Properties = @{ Application = "Octopus"; Server = "MyServer" }
-            DependsOn = "[cOctopusServer]OctopusServer"
         }
 
         cOctopusServerUsernamePasswordAuthentication "Enable Username/Password Auth"

--- a/Tests/Scenarios/Server_Scenario_03_Remove.ps1
+++ b/Tests/Scenarios/Server_Scenario_03_Remove.ps1
@@ -14,12 +14,6 @@ Configuration Server_Scenario_03_Remove
             ConfigurationMode = 'ApplyOnly'
         }
 
-        cOctopusSeqLogger "Disable logging to seq"
-        {
-            InstanceType = 'OctopusServer'
-            Ensure = 'Absent'
-        }
-
         cOctopusServer OctopusServer
         {
             Ensure = "Absent"
@@ -39,7 +33,6 @@ Configuration Server_Scenario_03_Remove
 
             # dont mess with stats
             AllowCollectionOfUsageStatistics = $false
-            DependsOn = "[cOctopusSeqLogger]Disable logging to seq"
         }
     }
 }

--- a/Tests/Scenarios/Tentacle_Scenario_01_Install.ps1
+++ b/Tests/Scenarios/Tentacle_Scenario_01_Install.ps1
@@ -1,6 +1,3 @@
-$seqPlainTextApiKey = ConvertTo-SecureString "MyMagicSeqApiKey" -AsPlainText -Force
-$seqApiKey = New-Object System.Management.Automation.PSCredential ("ignored", $seqPlainTextApiKey)
-
 $config = get-content "c:\temp\octopus-configured.marker" | ConvertFrom-Json
 $OctopusServerUrl = $config.OctopusServerUrl
 $ApiKey = $config.OctopusApiKey
@@ -50,16 +47,6 @@ Configuration Tentacle_Scenario_01_Install
             TenantedDeploymentParticipation = "TenantedOrUntenanted"
 
             Policy = "Test Policy"
-        }
-
-        cOctopusSeqLogger "Enable logging to seq"
-        {
-            InstanceType = "Tentacle"
-            Ensure = "Present"
-            SeqServer = "http://localhost/seq"
-            SeqApiKey = $seqApiKey
-            Properties = @{ Application = "Octopus"; Server = "MyServer" }
-            DependsOn = "[cTentacleAgent]ListeningTentacle"
         }
 
         cTentacleAgent PollingTentacle

--- a/Tests/Scenarios/Tentacle_Scenario_02_Remove.ps1
+++ b/Tests/Scenarios/Tentacle_Scenario_02_Remove.ps1
@@ -18,12 +18,6 @@ Configuration Tentacle_Scenario_02_Remove
             ConfigurationMode = 'ApplyOnly'
         }
 
-        cOctopusSeqLogger "Disable logging to seq"
-        {
-            InstanceType = 'Tentacle'
-            Ensure = 'Absent'
-        }
-
         cTentacleAgent ListeningTentacle
         {
             Ensure = "Absent";
@@ -43,7 +37,6 @@ Configuration Tentacle_Scenario_02_Remove
             ListenPort = 10933;
             DefaultApplicationDirectory = "C:\Applications"
             TentacleHomeDirectory = "C:\Octopus\ListeningTentacleHome"
-            DependsOn = "[cOctopusSeqLogger]Disable logging to seq"
         }
 
         cTentacleAgent PollingTentacle
@@ -66,7 +59,6 @@ Configuration Tentacle_Scenario_02_Remove
             DefaultApplicationDirectory = "C:\Applications"
             CommunicationMode = "Poll"
             TentacleHomeDirectory = "C:\Octopus\PollingTentacleHome"
-            DependsOn = "[cOctopusSeqLogger]Disable logging to seq"
         }
 
         cTentacleAgent ListeningTentacleWithoutAutoRegister
@@ -89,7 +81,6 @@ Configuration Tentacle_Scenario_02_Remove
             TentacleHomeDirectory = "C:\Octopus\ListeningTentacleWithoutAutoRegisterHome"
 
             RegisterWithServer = $false
-            DependsOn = "[cOctopusSeqLogger]Disable logging to seq"
         }
 
         cTentacleAgent ListeningTentacleWithThumbprintWithoutAutoRegister
@@ -113,7 +104,6 @@ Configuration Tentacle_Scenario_02_Remove
 
             RegisterWithServer = $false
             OctopusServerThumbprint = $ServerThumbprint
-            DependsOn = "[cOctopusSeqLogger]Disable logging to seq"
         }
 
         cTentacleAgent WorkerTentacle
@@ -165,7 +155,6 @@ Configuration Tentacle_Scenario_02_Remove
             TentacleHomeDirectory = "C:\Octopus\ListeningTentacleWithCustomAccountHome"
 
             TentacleServiceCredential = $serviceusercredential
-            DependsOn = "[cOctopusSeqLogger]Disable logging to seq"
         }
     }
 }

--- a/Tests/Spec/server_scenario_01_install_spec.rb
+++ b/Tests/Spec/server_scenario_01_install_spec.rb
@@ -71,21 +71,6 @@ describe octopus_deploy_worker_pool(ENV['OctopusServerUrl'], ENV['OctopusApiKey'
   it { should exist }
 end
 
-#seq logging
-describe file('C:/Program Files/Octopus Deploy/Octopus/Seq.Client.NLog.dll') do
-  it { should be_file }
-end
-
-describe file('C:/Program Files/Octopus Deploy/Octopus/Octopus.Server.exe.nlog') do
-  it { should be_file }
-  its(:content) { should match /<add assembly="Seq.Client.NLog" \/>/ }
-  its(:content) { should match /<logger name="\*" minlevel="Info" writeTo="seqbufferingwrapper" \/>/ }
-  its(:content) { should match /<target name=\"seqbufferingwrapper\" xsi:type=\"BufferingWrapper\" bufferSize=\"1000\" flushTimeout=\"2000\">/}
-  its(:content) { should match /<target name="seq" xsi:type="Seq" serverUrl="http:\/\/localhost\/seq" apiKey="MyMagicSeqApiKey">/ }
-  its(:content) { should match /<property name="Application" value="Octopus" \/>/ }
-  its(:content) { should match /<property name="Server" value="MyServer" \/>/ }
-end
-
 #dsc overall status
 describe windows_dsc do
   it { should be_able_to_get_dsc_configuration }

--- a/Tests/Spec/server_scenario_02_install_second_node_spec.rb
+++ b/Tests/Spec/server_scenario_02_install_second_node_spec.rb
@@ -74,21 +74,6 @@ describe octopus_deploy_environment(ENV['OctopusServerUrl'], ENV['OctopusApiKey'
   it { should exist }
 end
 
-#seq logging
-describe file('C:/Program Files/Octopus Deploy/Octopus/Seq.Client.NLog.dll') do
-  it { should be_file }
-end
-
-describe file('C:/Program Files/Octopus Deploy/Octopus/Octopus.Server.exe.nlog') do
-  it { should be_file }
-  its(:content) { should match /<add assembly="Seq.Client.NLog" \/>/ }
-  its(:content) { should match /<logger name="\*" minlevel="Info" writeTo="seqbufferingwrapper" \/>/ }
-  its(:content) { should match /<target name=\"seqbufferingwrapper\" xsi:type=\"BufferingWrapper\" bufferSize=\"1000\" flushTimeout=\"2000\">/}
-  its(:content) { should match /<target name="seq" xsi:type="Seq" serverUrl="http:\/\/localhost\/seq" apiKey="MyMagicSeqApiKey">/ }
-  its(:content) { should match /<property name="Application" value="Octopus" \/>/ }
-  its(:content) { should match /<property name="Server" value="MyServer" \/>/ }
-end
-
 #dsc overall status
 describe windows_dsc do
   it { should be_able_to_get_dsc_configuration }

--- a/Tests/Spec/tentacle_scenario_01_install_spec.rb
+++ b/Tests/Spec/tentacle_scenario_01_install_spec.rb
@@ -239,21 +239,6 @@ describe file('C:\Octopus\ListeningTentacleWithCustomAccountHome\ListeningTentac
   its(:content) { should match /Tentacle\.Communication\.TrustedOctopusServers.*#{config['OctopusServerThumbprint']}/}
 end
 
-#seq logging
-describe file('C:/Program Files/Octopus Deploy/Tentacle/Seq.Client.NLog.dll') do
-  it { should be_file }
-end
-
-describe file('C:/Program Files/Octopus Deploy/Tentacle/Tentacle.exe.nlog') do
-  it { should be_file }
-  its(:content) { should match /<add assembly="Seq.Client.NLog" \/>/ }
-  its(:content) { should match /<logger name="\*" minlevel="Info" writeTo="seqbufferingwrapper" \/>/ }
-  its(:content) { should match /<target name=\"seqbufferingwrapper\" xsi:type=\"BufferingWrapper\" bufferSize=\"1000\" flushTimeout=\"2000\">/}
-  its(:content) { should match /<target name="seq" xsi:type="Seq" serverUrl="http:\/\/localhost\/seq" apiKey="MyMagicSeqApiKey">/ }
-  its(:content) { should match /<property name="Application" value="Octopus" \/>/ }
-  its(:content) { should match /<property name="Server" value="MyServer" \/>/ }
-end
-
 ### DSC success
 describe windows_dsc do
   it { should be_able_to_get_dsc_configuration }


### PR DESCRIPTION
As it's stopped working with 2020.1, as Octopus got converted to netcore, and can no longer load a dll that is dropped into the application directory