### PR TITLE
Only call /workers/all once, rather than for each worker pool

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -124,14 +124,14 @@ function Get-WorkerPoolMembership
     $octoWorkerPools = Get-APIResult -ServerUrl $ServerUrl -ApiKey $ApiKey -API $apiUrl
 
     $workerPoolMembership = @()
+    $workersUrl = "/workers/all"
+    if (![String]::IsNullOrEmpty($SpaceId)) {
+        $workersUrl = "/$SpaceId" + $workersUrl
+    }
+    $workersall = Get-APIResult -ServerUrl $ServerUrl -ApiKey $ApiKey -API $workersUrl
 
     foreach ($octoWorkerPool in $octoWorkerPools)
     {
-        $workersUrl = "/workers/all"
-        if (![String]::IsNullOrEmpty($SpaceId)) {
-            $workersUrl = "/$SpaceId" + $workersUrl
-        }
-        $workersall = Get-APIResult -ServerUrl $ServerUrl -ApiKey $ApiKey -API $workersUrl
         $workers = $workersall | Where-Object { $_.WorkerPoolIds -contains $($octoWorkerPool.Id) }
         # Check to see if the thumbprint is listed
         $workerWithThumbprint = ($workers | Where-Object {$_.Thumbprint -eq $Thumbprint})


### PR DESCRIPTION
Dont need to make extra calls - its a global call, not a per worker pool call