### PR TITLE
Add inline tests for valid configuration for workerpools

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -141,11 +141,38 @@ function Test-ParameterSet {
         [AllowNull()]
         [AllowEmptyString()]
         [System.String]
-        $CustomPublicHostName
+        $CustomPublicHostName,
+        [System.String[]]
+        $Environments = "",
+        [System.String[]]
+        $Roles = "",
+        [System.String[]]
+        $WorkerPools,
+        [System.String[]]
+        $Tenants,
+        [System.String[]]
+        $TenantTags
     )
 
     if($publicHostNameConfiguration -eq "Custom" -and [String]::IsNullOrWhiteSpace($CustomPublicHostName)) {
-        throw "PublicHostNameConfiguration was set to 'Custom' but an invalid or null CustomPublicHostName was specified"
+        throw "Invalid configuration requested. " + `
+            "PublicHostNameConfiguration was set to 'Custom' but an invalid or null CustomPublicHostName was specified."
+    } elseif ((Test-Value($Environments)) -and (Test-Value($WorkerPools))) {
+        throw "Invalid configuration requested. " + `
+            "You have asked for the Tentacle to be registered as a worker, but still provided the 'Environments' configuration argument. " + `
+            "Please remove the 'Environments' configuration argument."
+    } elseif ((Test-Value($Roles)) -and (Test-Value($WorkerPools))) {
+        throw "Invalid configuration requested. " + `
+            "You have asked for the Tentacle to be registered as a worker, but still provided the 'Roles' configuration argument. " + `
+            "Please remove the 'Roles' configuration argument."
+    } elseif ((Test-Value($Tenants)) -and (Test-Value($WorkerPools))) {
+        throw "Invalid configuration requested. " + `
+            "You have asked for the Tentacle to be registered as a worker, but still provided the 'Tenants' configuration argument. " + `
+            "Please remove the 'Tenants' configuration argument."
+    } elseif ((Test-Value($TenantTags)) -and (Test-Value($WorkerPools))) {
+        throw "Invalid configuration requested. " + `
+            "You have asked for the Tentacle to be registered as a worker, but still provided the 'TenantTags' configuration argument. " + `
+            "Please remove the 'TenantTags' configuration argument."
     }
 }
 
@@ -205,7 +232,12 @@ function Get-TargetResource {
     )
 
     Test-ParameterSet   -publicHostNameConfiguration $PublicHostNameConfiguration `
-                        -customPublicHostName $CustomPublicHostName
+                        -customPublicHostName $CustomPublicHostName `
+                        -Environments $Environments `
+                        -Roles $Roles `
+                        -WorkerPools $WorkerPools `
+                        -Tenants $Tenants `
+                        -TenantTags $TenantTags
 
     Write-Verbose "Checking if Tentacle is installed"
     $installLocation = (Get-ItemProperty -path "HKLM:\Software\Octopus\Tentacle" -ErrorAction SilentlyContinue).InstallLocation
@@ -279,23 +311,23 @@ function Confirm-RegistrationParameter {
         }
     } elseif ((Test-Value($Roles)) -and (-not ($RegisterWithServer))) {
         throw "Invalid configuration requested. " + `
-            "You have asked for the Tentacle not to be registered with the server, but still provided a the 'Roles' configuration argument. " + `
+            "You have asked for the Tentacle not to be registered with the server, but still provided the 'Roles' configuration argument. " + `
             "Please remove the 'Roles' configuration argument or set 'RegisterWithServer = `$True'."
     } elseif ((Test-Value($Environments)) -and (-not ($RegisterWithServer))) {
         throw "Invalid configuration requested. " + `
-            "You have asked for the Tentacle not to be registered with the server, but still provided a the 'Environments' configuration argument. " + `
+            "You have asked for the Tentacle not to be registered with the server, but still provided the 'Environments' configuration argument. " + `
             "Please remove the 'Environments' configuration argument or set 'RegisterWithServer = `$True'."
     } elseif ((Test-Value($Tenants)) -and (-not ($RegisterWithServer))) {
         throw "Invalid configuration requested. " + `
-            "You have asked for the Tentacle not to be registered with the server, but still provided a the 'Tenants' configuration argument. " + `
+            "You have asked for the Tentacle not to be registered with the server, but still provided the 'Tenants' configuration argument. " + `
             "Please remove the 'Tenants' configuration argument or set 'RegisterWithServer = `$True'."
     } elseif ((Test-Value($TenantTags)) -and (-not ($RegisterWithServer))) {
         throw "Invalid configuration requested. " + `
-            "You have asked for the Tentacle not to be registered with the server, but still provided a the 'TenantTags' configuration argument. " + `
+            "You have asked for the Tentacle not to be registered with the server, but still provided the 'TenantTags' configuration argument. " + `
             "Please remove the 'TenantTags' configuration argument or set 'RegisterWithServer = `$True'."
     } elseif ((Test-Value($Policy)) -and (-not ($RegisterWithServer))) {
         throw "Invalid configuration requested. " + `
-            "You have asked for the Tentacle not to be registered with the server, but still provided a the 'Policy' configuration argument. " + `
+            "You have asked for the Tentacle not to be registered with the server, but still provided the 'Policy' configuration argument. " + `
             "Please remove the 'Policy' configuration argument or set 'RegisterWithServer = `$True'."
     } elseif ((-not (Test-Value($OctopusServerUrl))) -and (($RegisterWithServer))) {
         throw "Invalid configuration requested. " + `

--- a/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
@@ -28,6 +28,24 @@ try
                 }
             }
 
+            Context 'Test-ParameterSet' {
+                It 'Throws if PublicHostNameConfiguration is Custom but CustomPublicHostName not set' {
+                    { Test-ParameterSet -publicHostNameConfiguration "Custom" -CustomPublicHostName $null -WorkerPools @() -Environments @('My Env') -Roles @() -Tenants @() -TenantTags @()} | Should Throw "Invalid configuration requested"
+                }
+                It 'Throws if WorkerPools are provided and Environments are provided' {
+                    { Test-ParameterSet -publicHostNameConfiguration "PublicIp" -CustomPublicHostName $null -WorkerPools @('My Worker Pool') -Environments @('My Env') -Roles @() -Tenants @() -TenantTags @() } | Should Throw "Invalid configuration requested"
+                }
+                It 'Throws if WorkerPools are provided and Roles are provided' {
+                    { Test-ParameterSet -publicHostNameConfiguration "PublicIp" -CustomPublicHostName $null -WorkerPools @('My Worker Pool') -Environments @() -Roles @('My Roles') -Tenants @() -TenantTags @() } | Should Throw "Invalid configuration requested"
+                }
+                It 'Throws if WorkerPools are provided and Tenants are provided' {
+                    { Test-ParameterSet -publicHostNameConfiguration "PublicIp" -CustomPublicHostName $null -WorkerPools @('My Worker Pool') -Environments @() -Roles @() -Tenants @('Jim-Bob') -TenantTags @() } | Should Throw "Invalid configuration requested"
+                }
+                It 'Throws if WorkerPools are provided and Tenant Tags are provided' {
+                    { Test-ParameterSet -publicHostNameConfiguration "PublicIp" -CustomPublicHostName $null -WorkerPools @('My Worker Pool') -Environments @() -Roles @() -Tenants @() -TenantTags @('CustomerType/VIP') } | Should Throw "Invalid configuration requested"
+                }
+            }
+
             Context 'Confirm-RegistrationParameter' {
                 It 'Throws if RegisterWithServer is false but environment provided' {
                     { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False -Environments @('My Env') } | Should Throw "Invalid configuration requested"

--- a/Tests/Scenarios/Tentacle_Scenario_01_Install.ps1
+++ b/Tests/Scenarios/Tentacle_Scenario_01_Install.ps1
@@ -122,7 +122,6 @@ Configuration Tentacle_Scenario_01_Install
             # Registration - all parameters required
             ApiKey = $ApiKey;
             OctopusServerUrl = $OctopusServerUrl;
-            Roles = $Roles;
 
             # Optional settings
             ListenPort = 10937;

--- a/Tests/Scenarios/Tentacle_Scenario_02_Remove.ps1
+++ b/Tests/Scenarios/Tentacle_Scenario_02_Remove.ps1
@@ -120,7 +120,6 @@ Configuration Tentacle_Scenario_02_Remove
             # Registration - all parameters required
             ApiKey = $ApiKey;
             OctopusServerUrl = $OctopusServerUrl;
-            Roles = $Roles;
 
             # Optional settings
             ListenPort = 10937;


### PR DESCRIPTION
Workerpools do not have environments, roles, tenants or tenant tags