### PR TITLE
Fix up worker pool handling

### DIFF
--- a/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
@@ -79,6 +79,27 @@ try
                 }
             }
 
+            Context 'Get-WorkerPoolMembership' {
+                It 'always returns an array, even if only one item returned' {
+                    Mock Get-APIResult { return @( [pscustomobject] @{ Name = "Pool1"; Id = "WorkerPools-1" } )} -ParameterFilter {$api -eq "/workerpools/all"}
+                    Mock Get-APIResult { return @( [pscustomobject] @{ Name = "Worker1"; WorkerPoolIds = @("WorkerPools-1"); Thumbprint = "12345678"} )} -ParameterFilter {$api -eq "/workers/all"}
+                    $result = Get-WorkerPoolMembership -ServerUrl "https://example.com" -Thumbprint "12345678" -ApiKey "API-1234" -SpaceId $null
+
+                    $result.Count | Should -Not -Be $null
+                }
+            }
+
+            Context 'Get-WorkerPoolMembership' {
+                It 'always returns an array, even if only one item returned' {
+                    Mock Get-APIResult { return @( [pscustomobject] @{ Name = "Pool1"; Id = "WorkerPools-1" } )} -ParameterFilter {$api -eq "/workerpools/all"}
+                    Mock Get-APIResult { return @( [pscustomobject] @{ Name = "Worker1"; WorkerPoolIds = @("WorkerPools-1"); Thumbprint = "12345678"} )} -ParameterFilter {$api -eq "/workers/all"}
+                    $result = Get-WorkerPoolMembership -ServerUrl "http://localhost:8065" -Thumbprint "D80D5A3DF457E1EFB355451109588DBE26F59368" -ApiKey "API-JM91EXRDGJTCTT7SEEVMJ7E73R4" -SpaceId $null
+
+                    $result.GetType() | Should -Be "System.Object[]"
+                    $result.Count | Should -Not -Be $null
+                }
+            }
+
             Context 'Get-TargetResource' {
                 Mock Get-ItemProperty { return @{ InstallLocation = "c:\Octopus\Tentacle\Stub" }}
                 Mock Get-Service { return @{ Status = "Running" }}


### PR DESCRIPTION
We were treating workers as deployment targets, and trying to retrieve them from the `/api/machines` endpoint. They actually live under the `/api/workers` endpoint.
This also forces the `Get-WorkerPoolMembership` function to return an array, in an attempt to fix #245.

Maybe fixes #245