### PR TITLE
Update serverspec to get better network port closed test

### DIFF
--- a/Tests/Gemfile.lock
+++ b/Tests/Gemfile.lock
@@ -4,49 +4,49 @@ GEM
     diff-lcs (1.3)
     json (2.1.0)
     mini_portile2 (2.4.0)
-    multi_json (1.13.1)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
-    net-ssh (4.2.0)
+    multi_json (1.14.1)
+    net-scp (3.0.0)
+      net-ssh (>= 2.6.5, < 7.0.0)
+    net-ssh (6.0.2)
     net-telnet (0.1.1)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.8-x64-mingw32)
+    nokogiri (1.10.9-x64-mingw32)
       mini_portile2 (~> 2.4.0)
     octopus-serverspec-extensions (0.18.1)
       json (~> 2.1.0)
       rspec (~> 3.0)
       serverspec (~> 2)
       specinfra (~> 2)
-    rake (12.3.3)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-its (1.2.0)
+      rspec-support (~> 3.9.0)
+    rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.7.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
     rspec-teamcity (0.0.1)
       rspec (>= 2.99, >= 2.14.2, < 4)
-    serverspec (2.41.3)
+    serverspec (2.41.5)
       multi_json
       rspec (~> 3.0)
       rspec-its
       specinfra (~> 2.72)
     sfl (2.3)
-    specinfra (2.73.2)
+    specinfra (2.82.16)
       net-scp
-      net-ssh (>= 2.7, < 5.0)
-      net-telnet
+      net-ssh (>= 2.7)
+      net-telnet (= 0.1.1)
       sfl
 
 PLATFORMS
@@ -55,10 +55,10 @@ PLATFORMS
 
 DEPENDENCIES
   nokogiri
-  octopus-serverspec-extensions (~> 0.17.2)
+  octopus-serverspec-extensions (~> 0.18.1)
   rake
   rspec-teamcity (~> 0.0.1)
   serverspec
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/Tests/Spec/server_scenario_03_remove_spec.rb
+++ b/Tests/Spec/server_scenario_03_remove_spec.rb
@@ -19,15 +19,13 @@ describe windows_dsc do
   it { should have_dsc_configuration_status_of_success }
 end
 
-#todo: add a new type/matcher to the `octopus-serverspec-extensions` project
-#the port can still be in a TIME_WAIT state for upto 4 minutes and these tests can fail because of that
-#describe port(10943) do
-#  it { should_not be_listening.with('tcp') }
-#end
+describe port(10943) do
+  it { should_not be_listening.with('tcp') }
+end
 
-#describe port(81) do
-#  it { should_not be_listening.with('tcp') }
-#end
+describe port(81) do
+  it { should_not be_listening.with('tcp') }
+end
 
 #todo: confirm whether these should be deleted
 # describe windows_registry_key('HKEY_LOCAL_MACHINE\Software\Octopus\OctopusServer') do

--- a/Tests/Spec/server_scenario_04_remove_second_node_spec.rb
+++ b/Tests/Spec/server_scenario_04_remove_second_node_spec.rb
@@ -19,15 +19,13 @@ describe windows_dsc do
   it { should have_dsc_configuration_status_of_success }
 end
 
-#todo: add a new type/matcher to the `octopus-serverspec-extensions` project
-#the port can still be in a TIME_WAIT state for upto 4 minutes and these tests can fail because of that
-#describe port(10943) do
-#  it { should_not be_listening.with('tcp') }
-#end
+describe port(10943) do
+  it { should_not be_listening.with('tcp') }
+end
 
-#describe port(81) do
-#  it { should_not be_listening.with('tcp') }
-#end
+describe port(81) do
+  it { should_not be_listening.with('tcp') }
+end
 
 #todo: confirm whether these should be deleted
 # describe windows_registry_key('HKEY_LOCAL_MACHINE\Software\Octopus\OctopusServer') do

--- a/Tests/Spec/server_scenario_06_remove_custom_instance_spec.rb
+++ b/Tests/Spec/server_scenario_06_remove_custom_instance_spec.rb
@@ -19,15 +19,13 @@ describe windows_dsc do
   it { should have_dsc_configuration_status_of_success }
 end
 
-#todo: add a new type/matcher to the `octopus-serverspec-extensions` project
-#the port can still be in a TIME_WAIT state for upto 4 minutes and these tests can fail because of that
-#describe port(10943) do
-#  it { should_not be_listening.with('tcp') }
-#end
+describe port(10943) do
+  it { should_not be_listening.with('tcp') }
+end
 
-#describe port(81) do
-#  it { should_not be_listening.with('tcp') }
-#end
+describe port(81) do
+  it { should_not be_listening.with('tcp') }
+end
 
 #todo: confirm whether these should be deleted
 # describe windows_registry_key('HKEY_LOCAL_MACHINE\Software\Octopus\OctopusServer') do

--- a/Tests/Spec/server_scenario_11_remove_spec.rb
+++ b/Tests/Spec/server_scenario_11_remove_spec.rb
@@ -19,15 +19,13 @@ describe windows_dsc do
   it { should have_dsc_configuration_status_of_success }
 end
 
-#todo: add a new type/matcher to the `octopus-serverspec-extensions` project
-#the port can still be in a TIME_WAIT state for upto 4 minutes and these tests can fail because of that
-#describe port(10943) do
-#  it { should_not be_listening.with('tcp') }
-#end
+describe port(10943) do
+  it { should_not be_listening.with('tcp') }
+end
 
-#describe port(81) do
-#  it { should_not be_listening.with('tcp') }
-#end
+describe port(81) do
+  it { should_not be_listening.with('tcp') }
+end
 
 #todo: confirm whether these should be deleted
 # describe windows_registry_key('HKEY_LOCAL_MACHINE\Software\Octopus\OctopusServer') do

--- a/Tests/Spec/server_scenario_13_remove_spec.rb
+++ b/Tests/Spec/server_scenario_13_remove_spec.rb
@@ -19,15 +19,13 @@ describe windows_dsc do
   it { should have_dsc_configuration_status_of_success }
 end
 
-#todo: add a new type/matcher to the `octopus-serverspec-extensions` project
-#the port can still be in a TIME_WAIT state for upto 4 minutes and these tests can fail because of that
-#describe port(10943) do
-#  it { should_not be_listening.with('tcp') }
-#end
+describe port(10943) do
+  it { should_not be_listening.with('tcp') }
+end
 
-#describe port(81) do
-#  it { should_not be_listening.with('tcp') }
-#end
+describe port(81) do
+  it { should_not be_listening.with('tcp') }
+end
 
 #todo: confirm whether these should be deleted
 # describe windows_registry_key('HKEY_LOCAL_MACHINE\Software\Octopus\OctopusServer') do


### PR DESCRIPTION
Now we have better "is port not listening" test in serverspec with @benPearce1's [fix in SpecInfra](https://github.com/mizzy/specinfra/pull/716), we can uncomment some tests that weren't working so well due to ports on windows staying in a TIME_WAIT state.

@benPearce1 - tagging you on this as you've been in this space this week with the AzureVMExtension.
@andrewabest - tagging you as an fyi as you said you had been heavily into DSC in the past