### PR TITLE
Fix some worker registration issues

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -1047,20 +1047,15 @@ function Remove-TentacleRegistration {
 function Remove-WorkerPoolRegistration {
     param(
         [Parameter(Mandatory = $true)]
-        [string]
-        $octopusServerUrl,
+        [string]$octopusServerUrl,
         [Parameter(Mandatory = $true)]
-        [string]
-        $apiKey,
+        [string]$apiKey,
         [Parameter(Mandatory = $true)]
-        [PSCredential]
-        $TentacleServiceCredential,
-        [Parameter(Mandatory = $true)]
-        [string]
-        $name,
-        [Parameter(Mandatory = $true)]
-        [string]
-        $Space
+        [string]$name,
+        [Parameter(Mandatory = $True)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Space
     )
     if (Test-TentacleExecutableExists) {
         Write-Verbose "Deregistering $($env:ComputerName) from worker pools"

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/NewWorker/ExpectedResult.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/NewWorker/ExpectedResult.ps1
@@ -3,5 +3,5 @@ return @(
     "new-certificate --instance Tentacle --console",
     "configure --instance Tentacle --home C:\Octopus --app C:\Applications --console --port 10935",
     "service --install --instance Tentacle --console --reconfigure --username Admin --password S3cur3P4ssphraseHere!",
-    "register-worker --instance Tentacle --server http://localhost:81 --name My Worker --force --apiKey API-1234 --comms-style TentaclePassive --publicHostName mytestserver.local --workerpool NodeJSWorker"
+    "register-worker --instance Tentacle --server http://localhost:81 --apiKey API-1234 --name My Worker --force --comms-style TentaclePassive --publicHostName mytestserver.local --workerpool NodeJSWorker"
 )

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/NewWorkerInSpace/ExpectedResult.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/NewWorkerInSpace/ExpectedResult.ps1
@@ -3,5 +3,5 @@ return @(
     "new-certificate --instance Tentacle --console",
     "configure --instance Tentacle --home C:\Octopus --app C:\Applications --console --port 10935",
     "service --install --instance Tentacle --console --reconfigure --username Admin --password S3cur3P4ssphraseHere!",
-    "register-worker --instance Tentacle --server http://localhost:81 --name My Worker --force --space My Space --apiKey API-1234 --comms-style TentaclePassive --publicHostName mytestserver.local --workerpool NodeJSWorker"
+    "register-worker --instance Tentacle --server http://localhost:81 --apiKey API-1234 --name My Worker --force --space My Space --comms-style TentaclePassive --publicHostName mytestserver.local --workerpool NodeJSWorker"
 )

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/UninstallingRunningInstance/ExpectedResult.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/UninstallingRunningInstance/ExpectedResult.ps1
@@ -1,3 +1,4 @@
 return @(
   "deregister-from --instance Tentacle --server http://localhost:81 --apiKey API-1234 --console"
+  "deregister-worker --instance Tentacle --server http://localhost:81 --apiKey API-1234 --console"
 )

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/UninstallingRunningInstanceInSpace/ExpectedResult.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/UninstallingRunningInstanceInSpace/ExpectedResult.ps1
@@ -1,3 +1,4 @@
 return @(
   "deregister-from --instance Tentacle --server http://localhost:81 --apiKey API-1234 --console --space My Space"
+  "deregister-worker --instance Tentacle --server http://localhost:81 --apiKey API-1234 --console --space My Space"
 )


### PR DESCRIPTION
* We now deregister the worker on uninstall
* If we were already installed, we only register worker/tentacle if `$RegisterWithServer` is true
* We've stopped using the tentacle service credentials to try and auth with the server when registering or de-registering