### PR TITLE
Ensure Get-TargetResource returns all DSC properties

### DIFF
--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
@@ -149,6 +149,7 @@ function Get-TargetResource {
                 $existingLogTaskMetrics = $existingConfig.OctopusTasksRecordTaskMetrics
                 $existingLogRequestMetrics = $existingConfig.OctopusWebPortalRequestMetricLoggingEnabled
                 $existingTaskCap = $existingConfig.OctopusNodeTaskCap
+                $existingOctopusMasterKey = $existingConfig.OctopusMasterKey
 
                 #note: this can get out of sync with reality. Ideally we'd read from `show-configuration`,
                 #      but the catch is there can be multple admins. We'd probably need to add support for
@@ -198,14 +199,16 @@ function Get-TargetResource {
             OctopusServiceCredential                  = $existingOctopusServiceCredential;
             HomeDirectory                             = $existingHomeDirectory;
             LicenseKey                                = $existingLicenseKey;
-            GrantDatabasePermissions                  = $GrantDatabasePermissions;
             OctopusBuiltInWorkerCredential            = $existingOctopusBuiltInWorkerCredential;
             PackagesDirectory                         = $existingPackagesDirectory;
             ArtifactsDirectory                        = $existingArtifactsDirectory;
             TaskLogsDirectory                         = $existingTaskLogsDirectory;
             LogTaskMetrics                            = $existingLogTaskMetrics;
             LogRequestMetrics                         = $existingLogRequestMetrics;
-            TaskCap                                   = $existingTaskCap
+            TaskCap                                   = $existingTaskCap;
+            OctopusMasterKey                          = $existingOctopusMasterKey;
+            GrantDatabasePermissions                  = $GrantDatabasePermissions;
+            SkipLicenseCheck                          = $SkipLicenseCheck;
         }
 
         return $currentResource
@@ -265,6 +268,7 @@ function Import-ServerConfig {
             OctopusTasksRecordTaskMetrics                  = [System.Convert]::ToBoolean($config.Octopus.Tasks.RecordTaskMetrics)
             OctopusWebPortalRequestMetricLoggingEnabled    = [System.Convert]::ToBoolean($config.Octopus.WebPortal.RequestMetricLoggingEnabled)
             OctopusNodeTaskCap                             = $config.Octopus.Server.TaskCap
+            OctopusMasterKey                               = $config.OctopusMasterKey
         }
     }
     else {

--- a/OctopusDSC/OctopusDSCHelpers.ps1
+++ b/OctopusDSC/OctopusDSCHelpers.ps1
@@ -256,6 +256,9 @@ function Get-ServerConfiguration($instanceName) {
         }
     } -MaxRetries 3 -IntervalInMilliseconds 100
 
+    $masterkey = & $octopusServerExePath show-master-key --noconsolelogging --console --instance $instanceName
+    $config.OctopusMasterKey = $masterkey
+
     return $config
 }
 

--- a/OctopusDSC/OctopusDSCHelpers.ps1
+++ b/OctopusDSC/OctopusDSCHelpers.ps1
@@ -257,7 +257,7 @@ function Get-ServerConfiguration($instanceName) {
     } -MaxRetries 3 -IntervalInMilliseconds 100
 
     $masterkey = & $octopusServerExePath show-master-key --noconsolelogging --console --instance $instanceName
-    $config.OctopusMasterKey = $masterkey
+    $config | Add-Member -NotePropertyName "OctopusMasterKey" -NotePropertyValue $masterkey
 
     return $config
 }

--- a/OctopusDSC/Tests/OctopusServerExeInvocationFiles/WhenNothingChanges/CurrentState.ps1
+++ b/OctopusDSC/Tests/OctopusServerExeInvocationFiles/WhenNothingChanges/CurrentState.ps1
@@ -1,0 +1,33 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')] # these are tests, not anything that needs to be secure
+param()
+
+$pass = ConvertTo-SecureString "S3cur3P4ssphraseHere!" -AsPlainText -Force
+$octopusAdminCredential = New-Object System.Management.Automation.PSCredential ("Admin", $pass)
+$octopusBuiltInWorkerCredential = New-Object System.Management.Automation.PSCredential ("svcBuiltInWorker", $pass)
+
+$MasterKey = "Nc91+1kfZszMpe7DMne8wg=="
+$SecureMasterKey = ConvertTo-SecureString $MasterKey -AsPlainText -Force
+$MasterKeyCred = New-Object System.Management.Automation.PSCredential  ("notused", $SecureMasterKey)
+
+return @{
+  Ensure = "Present";
+  State = "Started";
+  Name = "OctopusServer";
+  WebListenPrefix = "http://localhost:82";
+  DownloadUrl = "https://octopus.com/downloads/latest/WindowsX64/OctopusServer";
+  SqlDbConnectionString = "Server=(local);Database=Octopus;Trusted_Connection=True;";
+  OctopusAdminCredential = $octopusAdminCredential;
+  ListenPort = 10935;
+  AllowCollectionOfUsageStatistics = $false;
+  HomeDirectory = "C:\Octopus";
+  TaskLogsDirectory = "C:\Octopus\TaskLogs";
+  PackagesDirectory = "C:\Octopus\Packages";
+  ArtifactsDirectory = "C:\Octopus\Artifacts";
+  AutoLoginEnabled = $true
+  LicenseKey = "PExpY2Vuc2UgU2lnbmF0dXJlPSJoUE5sNFJvYWx2T2wveXNUdC9Rak4xcC9PeVVQc0l6b0FJS282bk9VM1kzMUg4OHlqaUI2cDZGeFVDWEV4dEttdWhWV3hVSTR4S3dJcU9vMTMyVE1FUT09Ij4gICA8TGljZW5zZWRUbz5PY3RvVGVzdCBDb21wYW55PC9MaWNlbnNlZFRvPiAgIDxMaWNlbnNlS2V5PjI0NDE0LTQ4ODUyLTE1NDI3LTQxMDgyPC9MaWNlbnNlS2V5PiAgIDxWZXJzaW9uPjIuMDwhLS0gTGljZW5zZSBTY2hlbWEgVmVyc2lvbiAtLT48L1ZlcnNpb24+ICAgPFZhbGlkRnJvbT4yMDE3LTEyLTA4PC9WYWxpZEZyb20+ICAgPE1haW50ZW5hbmNlRXhwaXJlcz4yMDIzLTAxLTAxPC9NYWludGVuYW5jZUV4cGlyZXM+ICAgPFByb2plY3RMaW1pdD5VbmxpbWl0ZWQ8L1Byb2plY3RMaW1pdD4gICA8TWFjaGluZUxpbWl0PjE8L01hY2hpbmVMaW1pdD4gICA8VXNlckxpbWl0PlVubGltaXRlZDwvVXNlckxpbWl0PiA8L0xpY2Vuc2U+"
+  LogTaskMetrics=$true;
+  LogRequestMetrics=$true;
+  OctopusMasterKey = $MasterKeyCred;
+  ForceSSL = $true;
+  OctopusBuiltInWorkerCredential = $octopusBuiltInWorkerCredential;
+}

--- a/OctopusDSC/Tests/OctopusServerExeInvocationFiles/WhenNothingChanges/ExpectedResult.ps1
+++ b/OctopusDSC/Tests/OctopusServerExeInvocationFiles/WhenNothingChanges/ExpectedResult.ps1
@@ -1,0 +1,3 @@
+return @(
+  "configure --console --instance OctopusServer --upgradeCheck True --upgradeCheckWithStatistics False --webForceSSL True --webListenPrefixes http://localhost:82 --commsListenPort 10935 --home C:\Octopus --autoLoginEnabled True --hstsEnabled False --hstsMaxAge 3600"
+)

--- a/OctopusDSC/Tests/OctopusServerExeInvocationFiles/WhenNothingChanges/RequestedState.ps1
+++ b/OctopusDSC/Tests/OctopusServerExeInvocationFiles/WhenNothingChanges/RequestedState.ps1
@@ -1,0 +1,29 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '')] # these are tests, not anything that needs to be secure
+param()
+
+$pass = ConvertTo-SecureString "S3cur3P4ssphraseHere!" -AsPlainText -Force
+$octopusAdminCredential = New-Object System.Management.Automation.PSCredential ("Admin", $pass)
+$octopusBuiltInWorkerCredential = New-Object System.Management.Automation.PSCredential ("svcBuiltInWorker", $pass)
+
+$MasterKey = "Nc91+1kfZszMpe7DMne8wg=="
+$SecureMasterKey = ConvertTo-SecureString $MasterKey -AsPlainText -Force
+$MasterKeyCred = New-Object System.Management.Automation.PSCredential  ("notused", $SecureMasterKey)
+
+return @{
+    Ensure = "Present";
+    State = "Started";
+    Name = "OctopusServer";
+    WebListenPrefix = "http://localhost:82";
+    SqlDbConnectionString = "Server=(local);Database=Octopus;Trusted_Connection=True;";
+    OctopusAdminCredential = $octopusAdminCredential;
+    ListenPort = 10935;
+    AllowCollectionOfUsageStatistics = $false;
+    HomeDirectory = "C:\Octopus";
+    AutoLoginEnabled = $true
+    LicenseKey = "PExpY2Vuc2UgU2lnbmF0dXJlPSJoUE5sNFJvYWx2T2wveXNUdC9Rak4xcC9PeVVQc0l6b0FJS282bk9VM1kzMUg4OHlqaUI2cDZGeFVDWEV4dEttdWhWV3hVSTR4S3dJcU9vMTMyVE1FUT09Ij4gICA8TGljZW5zZWRUbz5PY3RvVGVzdCBDb21wYW55PC9MaWNlbnNlZFRvPiAgIDxMaWNlbnNlS2V5PjI0NDE0LTQ4ODUyLTE1NDI3LTQxMDgyPC9MaWNlbnNlS2V5PiAgIDxWZXJzaW9uPjIuMDwhLS0gTGljZW5zZSBTY2hlbWEgVmVyc2lvbiAtLT48L1ZlcnNpb24+ICAgPFZhbGlkRnJvbT4yMDE3LTEyLTA4PC9WYWxpZEZyb20+ICAgPE1haW50ZW5hbmNlRXhwaXJlcz4yMDIzLTAxLTAxPC9NYWludGVuYW5jZUV4cGlyZXM+ICAgPFByb2plY3RMaW1pdD5VbmxpbWl0ZWQ8L1Byb2plY3RMaW1pdD4gICA8TWFjaGluZUxpbWl0PjE8L01hY2hpbmVMaW1pdD4gICA8VXNlckxpbWl0PlVubGltaXRlZDwvVXNlckxpbWl0PiA8L0xpY2Vuc2U+"
+    LogTaskMetrics=$true;
+    LogRequestMetrics=$true;
+    OctopusMasterKey = $MasterKeyCred;
+    ForceSSL = $true;
+    OctopusBuiltInWorkerCredential = $octopusBuiltInWorkerCredential;
+}

--- a/OctopusDSC/Tests/cOctopusServer.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServer.Tests.ps1
@@ -159,6 +159,7 @@ try
 
                     it "should return a hashtable with an entry for <propertyName>" -TestCases $testCases {
                         param($propertyName, $propertyReturned)
+                        write-verbose "Property $propertyName should exist" # to keep psscriptanalyzer from complaining about PSReviewUnusedParameter
                         $propertyReturned | Should -Be $true
                     }
 

--- a/OctopusDSC/Tests/cOctopusServer.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServer.Tests.ps1
@@ -132,56 +132,27 @@ try
                 }
 
                 Context "Should return a hash table that lists all the resource properties as keys and the actual values" {
-                    $desiredConfiguration = Get-DesiredConfiguration
+                    $desiredConfiguration = @{
+                        Name                   = 'Stub'
+                        Ensure                 = 'Present'
+                        State                  = 'Started'
+                        WebListenPrefix        = "http://localhost:80"
+                        SqlDbConnectionString  = "conn-string"
+                        OctopusAdminCredential = New-Object System.Management.Automation.PSCredential ("Admin", (ConvertTo-SecureString "S3cur3P4ssphraseHere!" -AsPlainText -Force))
+                    }
                     $currentState = Get-TargetResource @desiredConfiguration
                     $expectedProperties = Get-PropertiesFromMof;
 
+                    $testCases = @()
                     foreach($expectedProperty in $expectedProperties) {
-                        it "should return a hashtable with an entry for $expectedProperty" {
-                            $currentState.ContainsKey($expectedProperty) | Should Be $true
-                        }
-                    }
-                }
-
-                function Get-PropertiesFromMof() {
-                    $moduleName = Split-Path ($PSCommandPath -replace '\.Tests\.ps1$', '') -Leaf
-                    $modulePath = Resolve-Path "$PSCommandPath/../../DSCResources/$moduleName/$moduleName.psm1"
-                    $mofFile = Get-Item ($modulePath -replace ".psm1", ".schema.mof")
-                    $schemaMofFileContent = Get-Content $mofFile
-
-                    $properties = @()
-                    foreach($line in $schemaMofFileContent) {
-                        if ($line -match "\s*(\[.*\])\s*(.*) (.*);") {
-                            $properties += $matches[3].Replace("[]", "");
-                        }
-                    }
-                    return $properties
-                }
-
-                Context "Should return a hash table that lists all the resource properties as keys and the actual values" {
-                    . $global:powershellHelpersPath
-
-                    $expectedProperties = Get-PropertiesFromMof | select-object @{ name="expectedProperty";expression={ $_ }} | ConvertTo-Hashtable;
-
-                    BeforeAll {
-                        $pass = ConvertTo-SecureString "S3cur3P4ssphraseHere!" -AsPlainText -Force
-                        $cred = New-Object System.Management.Automation.PSCredential ("Admin", $pass)
-
-                        $desiredConfiguration = @{
-                            Name                   = 'Stub'
-                            Ensure                 = 'Present'
-                            State                  = 'Started'
-                            WebListenPrefix        = "http://localhost:80"
-                            SqlDbConnectionString  = "conn-string"
-                            OctopusAdminCredential = $cred
-                        }
-                        $currentState = Get-TargetResource @desiredConfiguration
+                        $testCases += @{ propertyName = $expectedProperty; propertyReturned = $currentState.ContainsKey($expectedProperty) }
                     }
 
-                    it "should return a hashtable with an entry for <expectedProperty>" -TestCases $expectedProperties {
-                        param($expectedProperty)
-                        $currentState.ContainsKey($expectedProperty) | Should -Be $true
+                    it "should return a hashtable with an entry for <propertyName>" -TestCases $testCases {
+                        param($propertyName, $propertyReturned)
+                        $propertyReturned | Should -Be $true
                     }
+
                 }
             }
 

--- a/OctopusDSC/Tests/cOctopusServer.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServer.Tests.ps1
@@ -132,6 +132,15 @@ try
                 }
 
                 Context "Should return a hash table that lists all the resource properties as keys and the actual values" {
+                    # Get-Service is not available on mac/unix systems - fake it
+                    $getServiceCommand = Get-Command "Get-Service" -ErrorAction SilentlyContinue
+                    if ($null -eq $getServiceCommand) {
+                        function Get-Service {
+                            [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidOverwritingBuiltInCmdlets', '', Justification='Get-Service is not available on mac/unix systems, so without faking it, our builds fail')]
+                            param()
+                        }
+                    }
+
                     $desiredConfiguration = @{
                         Name                   = 'Stub'
                         Ensure                 = 'Present'


### PR DESCRIPTION
The MasterKey field was missing and it was causing the service to restart.

Relies on https://github.com/OctopusDeploy/OctopusDSC/pull/260 being merged first.

Fixes https://github.com/OctopusDeploy/OctopusDSC/issues/258