### PR TITLE
Upgrade tests to use Pester 5 syntax

### DIFF
--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
@@ -610,7 +610,7 @@ function Set-OctopusDeployConfiguration {
     )
 
     Write-Log "Configuring Octopus Deploy instance ..."
-    $args = @(
+    $cmdArgs = @(
         'configure',
         '--console',
         '--instance', $name,
@@ -621,12 +621,12 @@ function Set-OctopusDeployConfiguration {
         '--commsListenPort', $listenPort
     )
     if (($homeDirectory -ne "") -and ($null -ne $homeDirectory)) {
-        $args += @('--home', $homeDirectory)
+        $cmdArgs += @('--home', $homeDirectory)
     }
 
     if ($null -ne $autoLoginEnabled) {
         if (Test-OctopusVersionSupportsAutoLoginEnabled) {
-            $args += @('--autoLoginEnabled', $autoLoginEnabled)
+            $cmdArgs += @('--autoLoginEnabled', $autoLoginEnabled)
         }
         else {
             throw "AutoLoginEnabled is only supported from Octopus 3.5.0. Please pass `$null for versions older than this."
@@ -634,7 +634,7 @@ function Set-OctopusDeployConfiguration {
     }
 
     if (Test-OctopusVersionSupportsHsts) {
-        $args += @(
+        $cmdArgs += @(
             '--hstsEnabled', $hstsEnabled,
             '--hstsMaxAge', $hstsMaxAge
         )
@@ -653,31 +653,31 @@ function Set-OctopusDeployConfiguration {
         if ($legacyWebAuthenticationMode -eq 'Ignore') {
             throw "LegacyWebAuthenticationMode = 'ignore' is only supported from Octopus 3.5.0."
         }
-        $args += @('--webAuthenticationMode', $legacyWebAuthenticationMode)
+        $cmdArgs += @('--webAuthenticationMode', $legacyWebAuthenticationMode)
     }
 
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 
     if (
             (($null -ne $packagesDirectory) -and ($currentState['PackagesDirectory'] -ne $packagesDirectory)) -or
             (($null -ne $artifactsDirectory) -and ($currentState['ArtifactsDirectory'] -ne $artifactsDirectory)) -or
             (($null -ne $taskLogsDirectory) -and ($currentState['TaskLogsDirectory'] -ne $taskLogsDirectory))
         ) {
-        $args = $(
+        $cmdArgs = $(
             'path',
             '--console',
             '--instance', $name
         )
         if (($null -ne $packagesDirectory) -and ($currentState['PackagesDirectory'] -ne $packagesDirectory)) {
-            $args += @('--nugetRepository', $packagesDirectory)
+            $cmdArgs += @('--nugetRepository', $packagesDirectory)
         }
         if (($null -ne $artifactsDirectory) -and ($currentState['ArtifactsDirectory'] -ne $artifactsDirectory)) {
-            $args += @('--artifacts', $artifactsDirectory)
+            $cmdArgs += @('--artifacts', $artifactsDirectory)
         }
         if (($null -ne $taskLogsDirectory) -and ($currentState['TaskLogsDirectory'] -ne $taskLogsDirectory)) {
-            $args += @('--taskLogs', $taskLogsDirectory)
+            $cmdArgs += @('--taskLogs', $taskLogsDirectory)
         }
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
     }
 
     if ((-not (Test-OctopusVersionSupportsTaskMetricsLogging)) -and $logTaskMetrics) {
@@ -688,32 +688,32 @@ function Set-OctopusDeployConfiguration {
             (($null -ne $logTaskMetrics) -and ($currentState['LogTaskMetrics'] -ne $logTaskMetrics)) -or
             (($null -ne $logRequestMetrics) -and ($currentState['LogRequestMetrics'] -ne $logRequestMetrics))
         ) {
-        $args = $(
+        $cmdArgs = $(
             'metrics',
             '--console',
             '--instance', $name
         )
         if (($null -ne $logTaskMetrics) -and ($currentState['LogTaskMetrics'] -ne $logTaskMetrics)) {
-            $args += @('--tasks', $logTaskMetrics)
+            $cmdArgs += @('--tasks', $logTaskMetrics)
         }
         if (($null -ne $logRequestMetrics) -and ($currentState['LogRequestMetrics'] -ne $logRequestMetrics)) {
-            $args += @('--webapi', $logRequestMetrics)
+            $cmdArgs += @('--webapi', $logRequestMetrics)
         }
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
     }
 
     if ((Test-OctopusVersionSupportsTaskCap) -and ($taskCap -ne 0) -and ($currentState['TaskCap'] -ne $taskCap)) {
-        $args = $(
+        $cmdArgs = $(
             'node',
             '--console',
             '--instance', $name,
             '--taskCap', $taskCap
         )
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
     }
 
     if (Test-PSCredentialChanged $currentState['OctopusServiceCredential'] $OctopusServiceCredential) {
-        $args = @(
+        $cmdArgs = @(
             'service',
             '--console',
             '--instance', $name,
@@ -724,7 +724,7 @@ function Set-OctopusDeployConfiguration {
 
         if (-not (Test-PSCredentialIsNullOrEmpty $octopusServiceCredential)) {
             Write-Log "Reconfiguring Octopus Deploy service to use run as $($octopusServiceCredential.UserName) ..."
-            $args += @(
+            $cmdArgs += @(
                 '--username', $octopusServiceCredential.UserName,
                 '--password', $octopusServiceCredential.GetNetworkCredential().Password
             )
@@ -737,7 +737,7 @@ function Set-OctopusDeployConfiguration {
             Update-InstallState "OctopusServiceUsername" $null
             Update-InstallState "OctopusServicePassword" $null
         }
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
     }
 
     if (Test-PSCredentialChanged $currentState['OctopusAdminCredential'] $OctopusAdminCredential) {
@@ -745,7 +745,7 @@ function Set-OctopusDeployConfiguration {
             throw "'OctopusAdminCredential' must be supplied when creating a new instance"
         } elseif(-not (Test-PSCredentialIsNullOrEmpty $OctopusAdminCredential)) {
             Write-Log "Updating Octopus Deploy admin user to $($OctopusAdminCredential.UserName) ..."
-            $args = @(
+            $cmdArgs = @(
                 'admin',
                 '--console'
                 '--instance', $name,
@@ -755,28 +755,28 @@ function Set-OctopusDeployConfiguration {
 
             Update-InstallState "OctopusAdminUsername" $OctopusAdminCredential.UserName
             Update-InstallState "OctopusAdminPassword" ($OctopusAdminCredential.Password | ConvertFrom-SecureString)
-            Invoke-OctopusServerCommand $args
+            Invoke-OctopusServerCommand $cmdArgs
         }
     }
 
     if ($currentState['LicenseKey'] -ne $licenseKey) {
-        $args = @(
+        $cmdArgs = @(
             'license',
             '--console',
             '--instance', $name
         )
         if (($null -eq $licenseKey) -or ($licenseKey -eq "")) {
             Write-Log "Configuring Octopus Deploy instance to use free license ..."
-            $args += @('--free')
+            $cmdArgs += @('--free')
         } else {
             Write-Log "Configuring Octopus Deploy instance to use supplied license ..."
-            $args += @('--licenseBase64', $licenseKey)
+            $cmdArgs += @('--licenseBase64', $licenseKey)
 
             if ($skipLicenseCheck -and (Test-OctopusVersionSupportsSkipLicenseCheck)) {
-                $args += @('--skipLicenseCheck')
+                $cmdArgs += @('--skipLicenseCheck')
             }
         }
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
     }
 
     if (Test-PSCredentialChanged $currentState['OctopusBuiltInWorkerCredential'] $octopusBuiltInWorkerCredential) {
@@ -784,7 +784,7 @@ function Set-OctopusDeployConfiguration {
             if (-not (Test-PSCredentialIsNullOrEmpty $octopusBuiltInWorkerCredential)) {
                 Write-Log "Configuring Octopus Deploy to execute run-on-server scripts as $($octopusBuiltInWorkerCredential.UserName) ..."
 
-                $args = @(
+                $cmdArgs = @(
                     'builtin-worker',
                     '--instance', $name,
                     '--username', $octopusBuiltInWorkerCredential.UserName
@@ -794,7 +794,7 @@ function Set-OctopusDeployConfiguration {
                 Update-InstallState "OctopusRunAsPassword" ($octopusBuiltInWorkerCredential.Password | ConvertFrom-SecureString)
             } else {
                 Write-Log "Configuring Octopus Deploy to execute run-on-server scripts under the same account as the octopus.server.exe process..."
-                $args = @(
+                $cmdArgs = @(
                     'builtin-worker',
                     '--instance', $name,
                     '--reset'
@@ -802,7 +802,7 @@ function Set-OctopusDeployConfiguration {
                 Update-InstallState "OctopusRunAsUsername" $null
                 Update-InstallState "OctopusRunAsPassword" $null
             }
-            Invoke-OctopusServerCommand $args
+            Invoke-OctopusServerCommand $cmdArgs
         } else {
             throw "'OctopusBuiltInWorkerCredential' is only supported from Octopus 2018.1.0 and newer."
         }
@@ -852,22 +852,22 @@ function Test-ReconfigurationRequiresServiceRestart($currentState, $desiredState
 function Uninstall-OctopusDeploy($name, $currentState) {
     if ($currentState -eq "Started" -or $currentState -eq "Stopped") {
         Write-Log "Uninstalling Octopus Deploy service ..."
-        $args = @(
+        $cmdArgs = @(
             'service',
             '--stop',
             '--uninstall',
             '--console',
             '--instance', $name
         )
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
 
         Write-Log "Deleting Octopus Deploy instance ..."
-        $args = @(
+        $cmdArgs = @(
             'delete-instance',
             '--console',
             '--instance', $name
         )
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
     }
 
     $otherServices = Get-ExistingOctopusService
@@ -919,17 +919,17 @@ function Update-OctopusDeploy($name, $downloadUrl, $state, $webListenPrefix, $cu
 function Update-OctopusDatabase($name, $skipLicenseCheck) {
     if (Test-OctopusVersionSupportsDatabaseUpgrade) {
         Write-Log "Upgrading Octopus Database ..."
-        $args = @(
+        $cmdArgs = @(
             'database',
             '--upgrade',
             '--instance', $name
         )
 
         if ($skipLicenseCheck -and (Test-OctopusVersionSupportsSkipLicenseCheck)) {
-            $args += @('--skipLicenseCheck')
+            $cmdArgs += @('--skipLicenseCheck')
         }
 
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
     }
 }
 
@@ -938,13 +938,13 @@ function Start-OctopusDeployService($name, $webListenPrefix) {
     get-service (Get-ServiceName $name)  -ErrorAction SilentlyContinue | write-verbose
 
     Write-Log "Starting Octopus Deploy instance ..."
-    $args = @(
+    $cmdArgs = @(
         'service',
         '--start',
         '--console',
         '--instance', $name
     )
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 
     # split on semi colons for backwards compat
     $url = ($webListenPrefix -split ';')[0]
@@ -981,13 +981,13 @@ function Stop-OctopusDeployService($name) {
     get-service (Get-ServiceName $name)  -ErrorAction SilentlyContinue | write-verbose
 
     Write-Log "Stopping Octopus Deploy instance ..."
-    $args = @(
+    $cmdArgs = @(
         'service',
         '--stop',
         '--console',
         '--instance', $name
     )
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 }
 
 function Get-ServiceName {
@@ -1162,7 +1162,7 @@ function Install-OctopusDeploy {
     $isMasterKeyProvided = ($OctopusMasterKey -ne [PSCredential]::Empty)
 
     Write-Log "Creating Octopus Deploy instance ..."
-    $args = @(
+    $cmdArgs = @(
         'create-instance',
         '--console',
         '--instance', $name,
@@ -1170,17 +1170,17 @@ function Install-OctopusDeploy {
     )
     if (Test-OctopusVersionSupportsHomeDirectoryDuringCreateInstance) {
         if (($homeDirectory -ne "") -and ($null -ne $homeDirectory)) {
-            $args += @('--home', $homeDirectory)
+            $cmdArgs += @('--home', $homeDirectory)
         }
         else {
-            $args += @('--home', "$($env:SystemDrive)\Octopus")
+            $cmdArgs += @('--home', "$($env:SystemDrive)\Octopus")
         }
     }
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 
     Write-Log "Configuring Octopus Deploy instance ..."
 
-    $args = @(
+    $cmdArgs = @(
         'configure',
         '--console',
         '--instance', $name,
@@ -1218,25 +1218,25 @@ function Install-OctopusDeploy {
         Invoke-OctopusServerCommand $dbargs
     }
     else {
-        $args += @("--StorageConnectionString", $sqlDbConnectionString)
+        $cmdArgs += @("--StorageConnectionString", $sqlDbConnectionString)
 
         if ($isMasterKeyProvided) {
-            $args += @("--masterKey", $OctopusMasterKey.GetNetworkCredential().Password)
+            $cmdArgs += @("--masterKey", $OctopusMasterKey.GetNetworkCredential().Password)
         }
     }
 
     if (-not (Test-OctopusVersionSupportsHomeDirectoryDuringCreateInstance)) {
         if (($homeDirectory -ne "") -and ($null -ne $homeDirectory)) {
-            $args += @('--home', $homeDirectory)
+            $cmdArgs += @('--home', $homeDirectory)
         }
         else {
-            $args += @('--home', "$($env:SystemDrive)\Octopus")
+            $cmdArgs += @('--home', "$($env:SystemDrive)\Octopus")
         }
     }
 
     if ($null -ne $autoLoginEnabled) {
         if (Test-OctopusVersionSupportsAutoLoginEnabled) {
-            $args += @('--autoLoginEnabled', $autoLoginEnabled)
+            $cmdArgs += @('--autoLoginEnabled', $autoLoginEnabled)
         }
         else {
             throw "AutoLoginEnabled is only supported from Octopus 3.5.0. Please pass `$null for versions older than this."
@@ -1244,7 +1244,7 @@ function Install-OctopusDeploy {
     }
 
     if (Test-OctopusVersionSupportsHsts) {
-        $args += @(
+        $cmdArgs += @(
             '--hstsEnabled', $hstsEnabled,
             '--hstsMaxAge', $hstsMaxAge
         )
@@ -1263,14 +1263,14 @@ function Install-OctopusDeploy {
         if ($legacyWebAuthenticationMode -eq 'Ignore') {
             throw "LegacyWebAuthenticationMode = 'ignore' is only supported from Octopus 3.5.0."
         }
-        $args += @('--webAuthenticationMode', $legacyWebAuthenticationMode)
+        $cmdArgs += @('--webAuthenticationMode', $legacyWebAuthenticationMode)
     }
 
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 
     if (-not (Test-OctopusVersionNewerThan (New-Object System.Version 4, 0, 0))) {
         Write-Log "Creating Octopus Deploy database for v3..."
-        $args = @(
+        $cmdArgs = @(
             'database',
             '--console',
             '--instance', $name,
@@ -1278,7 +1278,7 @@ function Install-OctopusDeploy {
         )
 
         if ($isMasterKeyProvided) {
-            $args += @("--masterKey", $OctopusMasterKey.GetNetworkCredential().Password)
+            $cmdArgs += @("--masterKey", $OctopusMasterKey.GetNetworkCredential().Password)
         }
 
         if ($GrantDatabasePermissions) {
@@ -1289,10 +1289,10 @@ function Install-OctopusDeploy {
                 $databaseusername = "NT AUTHORITY\SYSTEM"
             }
             Write-Log "Granting database permissions to account $databaseusername"
-            $args += @('--grant', $databaseusername)
+            $cmdArgs += @('--grant', $databaseusername)
         }
 
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
     }
 
     Stop-OctopusDeployService -name $name
@@ -1301,7 +1301,7 @@ function Install-OctopusDeploy {
         Write-Log "Creating Admin User for Octopus Deploy instance ..."
         $extractedUserName = $OctopusAdminCredential.GetNetworkCredential().UserName
         $extractedPassword = $OctopusAdminCredential.GetNetworkCredential().Password
-        $args = @(
+        $cmdArgs = @(
             'admin',
             '--console',
             '--instance', $name,
@@ -1309,45 +1309,45 @@ function Install-OctopusDeploy {
             '--password', $extractedPassword
         )
 
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
         Update-InstallState "OctopusAdminUsername" $extractedUsername
         Update-InstallState "OctopusAdminPassword" ($OctopusAdminCredential.Password | ConvertFrom-SecureString)
     }
 
-    $args = @(
+    $cmdArgs = @(
         'license',
         '--console',
         '--instance', $name
     )
     if (($null -eq $licenseKey) -or ($licenseKey -eq "")) {
         Write-Log "Configuring Octopus Deploy instance to use free license ..."
-        $args += @('--free')
+        $cmdArgs += @('--free')
     } else {
         Write-Log "Configuring Octopus Deploy instance to use supplied license ..."
-        $args += @('--licenseBase64', $licenseKey)
+        $cmdArgs += @('--licenseBase64', $licenseKey)
 
         if ($skipLicenseCheck -and (Test-OctopusVersionSupportsSkipLicenseCheck)) {
-            $args += @('--skipLicenseCheck')
+            $cmdArgs += @('--skipLicenseCheck')
         }
     }
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 
     if (($null -ne $packagesDirectory) -or ($null -ne $artifactsDirectory) -or ($null -ne $taskLogsDirectory)) {
-        $args = $(
+        $cmdArgs = $(
             'path',
             '--console',
             '--instance', $name
         )
         if ($null -ne $packagesDirectory) {
-            $args += @('--nugetRepository', $packagesDirectory)
+            $cmdArgs += @('--nugetRepository', $packagesDirectory)
         }
         if ($null -ne $artifactsDirectory) {
-            $args += @('--artifacts', $artifactsDirectory)
+            $cmdArgs += @('--artifacts', $artifactsDirectory)
         }
         if ($null -ne $taskLogsDirectory) {
-            $args += @('--taskLogs', $taskLogsDirectory)
+            $cmdArgs += @('--taskLogs', $taskLogsDirectory)
         }
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
     }
 
     if ((-not (Test-OctopusVersionSupportsTaskMetricsLogging)) -and $logTaskMetrics) {
@@ -1355,33 +1355,33 @@ function Install-OctopusDeploy {
     }
 
     if ($logTaskMetrics -or $logRequestMetrics) {
-        $args = $(
+        $cmdArgs = $(
             'metrics',
             '--console',
             '--instance', $name
         )
 
         if ($logTaskMetrics) {
-            $args += @('--tasks', $logTaskMetrics)
+            $cmdArgs += @('--tasks', $logTaskMetrics)
         }
         if ($logRequestMetrics) {
-            $args += @('--webapi', $logRequestMetrics)
+            $cmdArgs += @('--webapi', $logRequestMetrics)
         }
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
     }
 
     if ((Test-OctopusVersionSupportsTaskCap) -and ($taskCap -ne 0)) {
-        $args = $(
+        $cmdArgs = $(
             'node',
             '--console',
             '--instance', $name,
             '--taskCap', $taskCap
         )
-        Invoke-OctopusServerCommand $args
+        Invoke-OctopusServerCommand $cmdArgs
     }
 
     Write-Log "Install Octopus Deploy service ..."
-    $args = @(
+    $cmdArgs = @(
         'service',
         '--console',
         '--instance', $name,
@@ -1392,7 +1392,7 @@ function Install-OctopusDeploy {
 
     if ($octopusServiceCredential) {
         Write-Log "Configuring service to run as $($octopusServiceCredential.UserName)"
-        $args += @(
+        $cmdArgs += @(
             "--username", $octopusServiceCredential.UserName,
             "--password", $octopusServiceCredential.GetNetworkCredential().Password
         )
@@ -1404,12 +1404,12 @@ function Install-OctopusDeploy {
         Update-InstallState "OctopusServiceUsername" $null
         Update-InstallState "OctopusServicePassword" $null
     }
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 
     if (($null -ne $octopusBuiltInWorkerCredential) -and ($octopusBuiltInWorkerCredential -ne [PSCredential]::Empty)) {
         if (Test-OctopusVersionSupportsRunAsCredential) {
             Write-Log "Configuring Octopus Deploy to execute run-on-server scripts as $($octopusBuiltInWorkerCredential.UserName) ..."
-            $args = @(
+            $cmdArgs = @(
                 'builtin-worker',
                 '--instance', $name,
                 '--username', $octopusBuiltInWorkerCredential.UserName,

--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
@@ -1417,7 +1417,7 @@ function Install-OctopusDeploy {
             )
             Update-InstallState "OctopusRunAsUsername" $octopusBuiltInWorkerCredential.UserName
             Update-InstallState "OctopusRunAsPassword" ($octopusBuiltInWorkerCredential.Password | ConvertFrom-SecureString)
-            Invoke-OctopusServerCommand $args
+            Invoke-OctopusServerCommand $cmdArgs
         } else {
             throw "'OctopusBuiltInWorkerCredential' is only supported from Octopus 4.2 and newer."
         }

--- a/OctopusDSC/DSCResources/cOctopusServerActiveDirectoryAuthentication/cOctopusServerActiveDirectoryAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerActiveDirectoryAuthentication/cOctopusServerActiveDirectoryAuthentication.psm1
@@ -47,7 +47,7 @@ function Set-TargetResource {
         [boolean]$AllowFormsAuthenticationForDomainUsers = $false,
         [string]$ActiveDirectoryContainer
     )
-    $args = @(
+    $cmdArgs = @(
         'configure',
         '--console',
         '--instance', $InstanceName,
@@ -55,7 +55,7 @@ function Set-TargetResource {
         '--allowFormsAuthenticationForDomainUsers', $AllowFormsAuthenticationForDomainUsers,
         '--activeDirectoryContainer', $ActiveDirectoryContainer
     )
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 }
 
 function Test-TargetResource {

--- a/OctopusDSC/DSCResources/cOctopusServerAzureADAuthentication/cOctopusServerAzureADAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerAzureADAuthentication/cOctopusServerAzureADAuthentication.psm1
@@ -47,7 +47,7 @@ function Set-TargetResource {
         [string]$Issuer,
         [string]$ClientId
     )
-    $args = @(
+    $cmdArgs = @(
         'configure',
         '--console',
         '--instance', $InstanceName,
@@ -55,7 +55,7 @@ function Set-TargetResource {
         '--azureADIssuer', $Issuer,
         '--azureADClientId', $ClientId
     )
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 }
 
 function Test-TargetResource {

--- a/OctopusDSC/DSCResources/cOctopusServerGoogleAppsAuthentication/cOctopusServerGoogleAppsAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerGoogleAppsAuthentication/cOctopusServerGoogleAppsAuthentication.psm1
@@ -47,7 +47,7 @@ function Set-TargetResource {
         [string]$ClientID,
         [string]$HostedDomain
     )
-    $args = @(
+    $cmdArgs = @(
         'configure',
         '--console',
         '--instance', $InstanceName,
@@ -55,7 +55,7 @@ function Set-TargetResource {
         '--googleAppsClientId', $ClientID,
         '--googleAppsHostedDomain', $HostedDomain
     )
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 }
 
 function Test-TargetResource {

--- a/OctopusDSC/DSCResources/cOctopusServerGuestAuthentication/cOctopusServerGuestAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerGuestAuthentication/cOctopusServerGuestAuthentication.psm1
@@ -41,13 +41,13 @@ function Set-TargetResource {
         [Parameter(Mandatory)]
         [boolean]$Enabled
     )
-    $args = @(
+    $cmdArgs = @(
         'configure',
         '--console',
         '--instance', $InstanceName,
         '--guestLoginEnabled', $Enabled
     )
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 }
 
 function Test-TargetResource {

--- a/OctopusDSC/DSCResources/cOctopusServerOktaAuthentication/cOctopusServerOktaAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerOktaAuthentication/cOctopusServerOktaAuthentication.psm1
@@ -47,7 +47,7 @@ function Set-TargetResource {
         [string]$Issuer,
         [string]$ClientId
     )
-    $args = @(
+    $cmdArgs = @(
         'configure',
         '--console',
         '--instance', $InstanceName,
@@ -55,7 +55,7 @@ function Set-TargetResource {
         '--oktaIssuer', $Issuer,
         '--oktaClientId', $ClientId
     )
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 }
 
 function Test-TargetResource {

--- a/OctopusDSC/DSCResources/cOctopusServerUsernamePasswordAuthentication/cOctopusServerUsernamePasswordAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerUsernamePasswordAuthentication/cOctopusServerUsernamePasswordAuthentication.psm1
@@ -41,13 +41,13 @@ function Set-TargetResource {
         [Parameter(Mandatory)]
         [boolean]$Enabled
     )
-    $args = @(
+    $cmdArgs = @(
         'configure',
         '--console',
         '--instance', $InstanceName,
         '--usernamePasswordIsEnabled', $Enabled
     )
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 }
 
 function Test-TargetResource {

--- a/OctopusDSC/DSCResources/cOctopusServerWatchdog/cOctopusServerWatchdog.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerWatchdog/cOctopusServerWatchdog.psm1
@@ -49,7 +49,7 @@ function Set-TargetResource {
         [string]$Instances = "*"
     )
     if ($Enabled) {
-        $args = @(
+        $cmdArgs = @(
             'watchdog',
             '--create',
             '--interval', $Interval,
@@ -57,12 +57,12 @@ function Set-TargetResource {
         )
     }
     else {
-        $args = @(
+        $cmdArgs = @(
             'watchdog',
             '--delete'
         )
     }
-    Invoke-OctopusServerCommand $args
+    Invoke-OctopusServerCommand $cmdArgs
 }
 
 function Test-TargetResource {

--- a/OctopusDSC/DSCResources/cTentacleWatchdog/cTentacleWatchdog.psm1
+++ b/OctopusDSC/DSCResources/cTentacleWatchdog/cTentacleWatchdog.psm1
@@ -105,18 +105,6 @@ function Test-TargetResource
   return $currentConfigurationMatchesRequestedConfiguration
 }
 
-function Invoke-TentacleCommand ($arguments)
-{
-  Write-Verbose "Executing command '$tentacleExePath $($arguments -join ' ')'"
-  $output = .$tentacleExePath $arguments
-
-  Write-CommandOutput $output
-  if (($null -ne $LASTEXITCODE) -and ($LASTEXITCODE -ne 0)) {
-    Write-Error "Command returned exit code $LASTEXITCODE. Aborting."
-    exit 1
-  }
-  Write-Verbose "done."
-}
 function Test-TentacleSupportsShowConfiguration
 {
   if (-not (Test-Path -LiteralPath $tentacleExePath))

--- a/OctopusDSC/DSCResources/cTentacleWatchdog/cTentacleWatchdog.psm1
+++ b/OctopusDSC/DSCResources/cTentacleWatchdog/cTentacleWatchdog.psm1
@@ -51,7 +51,7 @@ function Set-TargetResource
     [string]$Instances = "*"
   )
   if ($Enabled) {
-    $args = @(
+    $cmdArgs = @(
       'watchdog',
       '--create',
       '--interval', $Interval,
@@ -59,12 +59,12 @@ function Set-TargetResource
     )
   }
   else {
-    $args = @(
+    $cmdArgs = @(
       'watchdog',
       '--delete'
     )
   }
-  Invoke-TentacleCommand $args
+  Invoke-TentacleCommand $cmdArgs
 }
 
 function Test-TargetResource

--- a/OctopusDSC/Examples/cTentacleAgent_ListeningTentacle.psm1
+++ b/OctopusDSC/Examples/cTentacleAgent_ListeningTentacle.psm1
@@ -7,6 +7,7 @@ $ServiceCred = New-Object PSCredential "ServiceUser", $password
 
 Configuration SampleConfig
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="ReviewUnusedParameter does not capture parameter usage within a scriptblock.  See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472")]
     param ([string]$ApiKey, [string]$OctopusServerUrl, [string[]]$Environments, [string[]]$Roles, [int]$ListenPort, [string]$Space)
 
     Import-DscResource -Module OctopusDSC

--- a/OctopusDSC/Examples/cTentacleAgent_PollingTentacle.psm1
+++ b/OctopusDSC/Examples/cTentacleAgent_PollingTentacle.psm1
@@ -3,6 +3,7 @@
 
 Configuration SampleConfig
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="ReviewUnusedParameter does not capture parameter usage within a scriptblock.  See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472")]
     param ([string]$ApiKey, [string]$OctopusServerUrl, [string[]]$Environments, [string[]]$Roles, [int]$ServerPort, [string]$Space)
 
     Import-DscResource -Module OctopusDSC

--- a/OctopusDSC/OctopusDSCHelpers.ps1
+++ b/OctopusDSC/OctopusDSCHelpers.ps1
@@ -18,6 +18,16 @@ function Get-ODSCParameter($parameters) {
     return $params
 }
 
+function Test-GetODSCParameter {
+    param(
+        $Name,
+        $Ensure,
+        $DefaultValue = 'default'
+    )
+   return (Get-ODSCParameter $MyInvocation.MyCommand.Parameters)
+}
+
+
 function Invoke-WebClient($url, $OutFile) {
     $downloader = new-object System.Net.WebClient
     $downloader.DownloadFile($url, $OutFile)
@@ -173,18 +183,18 @@ Function Get-MaskedOutput
     return $out
 }
 
-function Invoke-OctopusServerCommand ($arguments) {
+function Invoke-OctopusServerCommand ($cmdArgs) {
     # todo: fix this up
-    if ((($arguments -match "masterkey|password|license|pwd=").Count -eq 0)) {
-        Write-Verbose "Executing command '$octopusServerExePath $($arguments -join ' ')'"
+    if ((($cmdArgs -match "masterkey|password|license|pwd=").Count -eq 0)) {
+        Write-Verbose "Executing command '$octopusServerExePath $($cmdArgs -join ' ')'"
     } else {
         $copiedarguments = @() # hack to pass a copy of the array, not a reference
-        $copiedarguments += $arguments
+        $copiedarguments += $cmdArgs
         $maskedarguments = Get-MaskedOutput $copiedarguments
         Write-Verbose "Executing command '$octopusServerExePath $($maskedarguments -join ' ')'"
     }
     $LASTEXITCODE = 0
-    $output = & $octopusServerExePath $arguments 2>&1
+    $output = & $octopusServerExePath $cmdArgs 2>&1
 
     Write-CommandOutput $output
     if (($null -ne $LASTEXITCODE) -and ($LASTEXITCODE -ne 0)) {
@@ -199,18 +209,18 @@ function Test-TentacleExecutableExists {
     return ((test-path $tentacleDir) -and (test-path "$tentacleDir\tentacle.exe"))
 }
 
-function Invoke-TentacleCommand ($arguments) {
+function Invoke-TentacleCommand ($cmdArgs) {
     # todo: fix this up
-    if ((($arguments -match "masterkey|password|license|pwd=").Count -eq 0)) {
-        Write-Verbose "Executing command '$tentacleExePath $($arguments -join ' ')'"
+    if ((($cmdArgs -match "masterkey|password|license|pwd=").Count -eq 0)) {
+        Write-Verbose "Executing command '$tentacleExePath $($cmdArgs -join ' ')'"
     } else {
         $copiedarguments = @() # hack to pass a copy of the array, not a reference
-        $copiedarguments += $arguments
+        $copiedarguments += $cmdArgs
         $maskedarguments = Get-MaskedOutput $copiedarguments
         Write-Verbose "Executing command '$tentacleExePath $($maskedarguments -join ' ')'"
     }
     $LASTEXITCODE = 0
-    $output = & $tentacleExePath $arguments 2>&1
+    $output = & $tentacleExePath $cmdArgs 2>&1
 
     Write-CommandOutput $output
     if (($null -ne $LASTEXITCODE) -and ($LASTEXITCODE -ne 0)) {

--- a/OctopusDSC/Tests/OctopusDSCHelpers.Tests.ps1
+++ b/OctopusDSC/Tests/OctopusDSCHelpers.Tests.ps1
@@ -26,8 +26,6 @@ Describe "Request-File" {
         BeforeAll {
             . $script:modulePath
             Mock Invoke-WebRequest {
-                param($uri, $saveAs, [switch]$UseBasicParsing, $Method)
-
                 return [pscustomobject]@{
                     Headers = @{'x-amz-meta-sha256' = "abcdef1234567890"};
                 }
@@ -48,8 +46,6 @@ Describe "Request-File" {
         BeforeAll {
             . $script:modulePath
             Mock Invoke-WebRequest {
-                param($uri, $saveAs, [switch]$UseBasicParsing, $Method)
-
                 return [pscustomobject]@{
                     Headers = @{'x-amz-meta-sha256' = "abcdef1234567891"};
                 }

--- a/OctopusDSC/Tests/OctopusDSCHelpers.Tests.ps1
+++ b/OctopusDSC/Tests/OctopusDSCHelpers.Tests.ps1
@@ -1,47 +1,42 @@
 $moduleName = Split-Path ($PSCommandPath -replace '\.Tests\.ps1$', '') -Leaf
 $modulePath = Split-Path $PSCommandPath -Parent
-$modulePath = Resolve-Path "$PSCommandPath/../../$moduleName.ps1"
+$script:modulePath = Resolve-Path "$PSCommandPath/../../$moduleName.ps1"
 
-. $modulePath
+. $script:modulePath
 
-$samplePath = Split-Path $PSCommandPath -parent
-$samplePath = Resolve-path "$samplePath/SampleConfigs/"
+$script:SamplePath = Split-Path $PSCommandPath -parent
+$script:samplePath = Resolve-path "$script:SamplePath/SampleConfigs/"
 
 Describe "Get-ODSCParameter" {
-    $desiredConfiguration = @{
-        Name                   = 'Stub'
-        Ensure                 = 'Present'
+    BeforeAll {
+        . $script:modulePath
     }
 
-    Function Test-GetODSCParameter
-    {
-        param(
-            $Name,
-            $Ensure,
-            $DefaultValue = 'default'
-        )
-       return (Get-ODSCParameter $MyInvocation.MyCommand.Parameters)
-    }
-
-    It "Should be able to return our known default values" {
-        (Test-GetODSCParameter @desiredConfiguration).DefaultValue | Should be 'default'
+    It "should be able to return our known default values" {
+        $desiredConfiguration = @{
+            Name                   = 'Stub'
+            Ensure                 = 'Present'
+        }
+        (Test-GetODSCParameter @desiredConfiguration).DefaultValue | Should -Be 'default'
     }
 }
 
 Describe "Request-File" {
     Context "It shouldn't download when hashes match" {
-        Mock Invoke-WebRequest {
-            param($uri, $saveAs, [switch]$UseBasicParsing, $Method)
+        BeforeAll {
+            . $script:modulePath
+            Mock Invoke-WebRequest {
+                param($uri, $saveAs, [switch]$UseBasicParsing, $Method)
 
-            return [pscustomobject]@{
-                Headers = @{'x-amz-meta-sha256' = "abcdef1234567890"};
-            }
-        } -Verifiable
-        Mock Invoke-WebClient -Verifiable
+                return [pscustomobject]@{
+                    Headers = @{'x-amz-meta-sha256' = "abcdef1234567890"};
+                }
+            } -Verifiable
+            Mock Invoke-WebClient -Verifiable
 
-        Mock Get-FileHash { return [pscustomobject]@{Hash =  "abcdef1234567890"} }
-        Mock Test-Path { return $true }
-
+            Mock Get-FileHash { return [pscustomobject]@{Hash =  "abcdef1234567890"} }
+            Mock Test-Path { return $true }
+        }
         It "Should only request the file hash and not download the file" {
             Request-File 'https://octopus.com/downloads/latest/WindowsX64/OctopusServer' $env:tmp\OctopusServer.msi # -verbose
             Assert-MockCalled "Invoke-WebRequest" -ParameterFilter {$Method -eq "HEAD" } -Times 1
@@ -50,18 +45,20 @@ Describe "Request-File" {
     }
 
     Context "It should download when hashes mismatch" {
-        Mock Invoke-WebRequest {
-            param($uri, $saveAs, [switch]$UseBasicParsing, $Method)
+        BeforeAll {
+            . $script:modulePath
+            Mock Invoke-WebRequest {
+                param($uri, $saveAs, [switch]$UseBasicParsing, $Method)
 
-            return [pscustomobject]@{
-                Headers = @{'x-amz-meta-sha256' = "abcdef1234567891"};
-            }
-        } -Verifiable
-        Mock Invoke-WebClient -Verifiable
+                return [pscustomobject]@{
+                    Headers = @{'x-amz-meta-sha256' = "abcdef1234567891"};
+                }
+            } -Verifiable
+            Mock Invoke-WebClient -Verifiable
 
-        Mock Get-FileHash { return [pscustomobject]@{Hash =  "abcdef1234567890"} }
-        Mock Test-Path { return $true }
-
+            Mock Get-FileHash { return [pscustomobject]@{Hash =  "abcdef1234567890"} }
+            Mock Test-Path { return $true }
+        }
         It "Should request the file has and also download the file" {
             Request-File 'https://octopus.com/downloads/latest/WindowsX64/OctopusServer' $env:tmp\OctopusServer.msi # -verbose
             Assert-MockCalled "Invoke-WebRequest"  -Times 1
@@ -71,86 +68,108 @@ Describe "Request-File" {
 }
 
 Describe "Invoke-OctopusServerCommand" {
-    Context "It should not leak password or masterkey" {
-        $OctopusServerExePath = "echo"
-        Write-Output "Mocked OctopusServerExePath as $OctopusServerExePath"
-        Mock Write-Verbose { } -verifiable
-        Function Write-CommandOutput {}
+    Context "It should not leak passwords" {
 
-        $dbargs = @("database",
-            "--connectionstring", "Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200",
-            "--masterKey", "ABCD123456ASDBD",
-            "--instance", "OctopusServer")
-        $pwargs = @("database",
-            "--instance", "OctopusServer",
-            "--connectionstring", "Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200;username=sa;password=p@ssword1234!")
-        $pwargs2 = @("database",
-            "--connectionstring", "Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200;username=sa;pwd=p@ssword1234!",
-            "--instance", "OctopusServer")
-        $lcargs = @("license",
-            "--console",
-            "--instance", "OctopusServer",
-            "--licenseBase64", "khsandvlinfaslkndsafdvlkjnvdsakljnvasdfkjnsdavkjnvfwq45o3ragoahwer4")
-        $npkargs = @("database",
-            "--instance", "OctopusServer",
-            "--connectionstring", "Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200;")
+        BeforeAll {
+            . $script:modulePath
+            $octopusServerExePath = "echo"
+            Write-Output "Mocked OctopusServerExePath as $OctopusServerExePath"
+            Mock Write-Verbose { } -verifiable
+            Mock Write-CommandOutput {}
+        }
 
         It "Doesn't try to mask output when no sensitive values exist " {
+            $npkargs = @("database",
+                "--instance", "OctopusServer",
+                "--connectionstring", "Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200;")
             Invoke-OctopusServerCommand $npkargs
             Assert-MockCalled Write-Verbose -parameterfilter { $Message -like "*echo database --instance OctopusServer --connectionstring Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200;*" } -times 1
         }
 
         It "Tries to mask the master key" {
+            $dbargs = @("database",
+                "--connectionstring", "Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200",
+                "--masterKey", "ABCD123456ASDBD",
+                "--instance", "OctopusServer")
             Invoke-OctopusServerCommand $dbargs
             Assert-MockCalled Write-Verbose -parameterfilter { $message -like "*echo database --connectionstring Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200 --masterKey *************** --instance OctopusServer'*"} -times 1  # has at least four asterisks
         }
 
         It "Tries to mask the Connectionstring password" {
+            $pwargs = @("database",
+                "--instance", "OctopusServer",
+                "--connectionstring", "Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200;username=sa;password=p@ssword1234!")
             Invoke-OctopusServerCommand $pwargs
             Assert-MockCalled Write-Verbose -parameterfilter { $Message -like "*echo database --instance OctopusServer --connectionstring Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200;username=sa;password=********'*"}  -times 1
         }
 
         It "Tries to mask the licencebase64" {
+            $lcargs = @("license",
+                "--console",
+                "--instance", "OctopusServer",
+                "--licenseBase64", "khsandvlinfaslkndsafdvlkjnvdsakljnvasdfkjnsdavkjnvfwq45o3ragoahwer4")
             Invoke-OctopusServerCommand $lcargs
             Assert-MockCalled Write-Verbose -parameterfilter { $Message -like "*echo license --console --instance OctopusServer --licenseBase64 *******************************************************************'*"}  -times 1
         }
 
         It "Should successfully mask the SQL password" {
-            ((Get-MaskedOutput $pwargs) -match "p@ssword1234!").Count | Should be 0
+            $pwargs = @("database",
+                "--instance", "OctopusServer",
+                "--connectionstring", "Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200;username=sa;password=p@ssword1234!")
+            ((Get-MaskedOutput $pwargs) -match "p@ssword1234!").Count | Should -Be 0
         }
 
         It "Should successfully mask a short-arg SQL password" {
-            ((Get-MaskedOutput $pwargs2) -match "p@ssword1234!").Count | Should be 0
+            $pwargs2 = @("database",
+                "--connectionstring", "Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200;username=sa;pwd=p@ssword1234!",
+                "--instance", "OctopusServer")
+            ((Get-MaskedOutput $pwargs2) -match "p@ssword1234!").Count | Should -Be 0
         }
 
         It "Should successfully mask the licence key" {
+            $lcargs = @("license",
+                "--console",
+                "--instance", "OctopusServer",
+                "--licenseBase64", "khsandvlinfaslkndsafdvlkjnvdsakljnvasdfkjnsdavkjnvfwq45o3ragoahwer4")
             $licence = "khsandvlinfaslkndsafdvlkjnvdsakljnvasdfkjnsdavkjnvfwq45o3ragoahwer4"
-            ((Get-MaskedOutput $lcargs) -match $licence).Count | Should Be 0
-            ((Get-MaskedOutput $lcargs) -match "\*\*\*\*").Count -gt 0 | Should Be $true
+            ((Get-MaskedOutput $lcargs) -match $licence).Count | Should -Be 0
+            ((Get-MaskedOutput $lcargs) -match "\*\*\*\*").Count -gt 0 | Should -Be $true
         }
 
         It "Should successfully mask the master key" {
-            ((Get-MaskedOutput $dbargs) -match "ABCD123456ASDBD").Count | Should Be 0
-            ((Get-MaskedOutput $dbargs) -match "\*\*\*\*").Count -gt 0 | Should Be $true
+            $dbargs = @("database",
+                "--connectionstring", "Data Source=mydbserver;Initial Catalog=Octopus;Integrated Security=SSPI;Max Pool Size=200",
+                "--masterKey", "ABCD123456ASDBD",
+                "--instance", "OctopusServer")
+            ((Get-MaskedOutput $dbargs) -match "ABCD123456ASDBD").Count | Should -Be 0
+            ((Get-MaskedOutput $dbargs) -match "\*\*\*\*").Count -gt 0 | Should -Be $true
         }
     }
 }
 
 Describe "Test-ValidJson" {
+    BeforeAll {
+        . $script:modulePath
+    }
+
     It "Returns false for known bad json" {
-        Test-ValidJson (Get-Content "$SamplePath\octopus.server.exe-output-when-json-has-exception-prepended.json" -raw) | Should Be $false
-     }
+        Test-ValidJson (Get-Content "$script:SamplePath\octopus.server.exe-output-when-json-has-exception-prepended.json" -raw) | Should -Be $false
+    }
 
     It "returns true for known good json" {
-        Test-ValidJson (Get-Content "$SamplePath\octopus.server.exe-output-clean.json" -raw) | Should Be $true
+        Test-ValidJson (Get-Content "$script:SamplePath\octopus.server.exe-output-clean.json" -raw) | Should -Be $true
     }
 }
 
 Describe "Get-CleanedJson" {
-    Mock Write-Warning {} # supress warning text
+    BeforeAll {
+        . $script:modulePath
+    }
+
     It "Correctly cleans our expected exception-prepended output" {
-        $clean = Get-CleanedJson (Get-Content "$SamplePath\octopus.server.exe-output-when-json-has-exception-prepended.json" -raw)
-        Test-ValidJson $clean | Should Be $true
-        $clean -eq (Get-Content "$SamplePath\octopus.server.exe-output-clean.json" -raw) | Should Be $true
+        Mock Write-Warning {} # supress warning text
+        $clean = Get-CleanedJson (Get-Content "$script:SamplePath\octopus.server.exe-output-when-json-has-exception-prepended.json" -raw)
+        Test-ValidJson $clean | Should -Be $true
+        $clean -eq (Get-Content "$script:SamplePath\octopus.server.exe-output-clean.json" -raw) | Should -Be $true
     }
 }

--- a/OctopusDSC/Tests/cOctopusEnvironment.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusEnvironment.Tests.ps1
@@ -38,13 +38,13 @@ try
                                                  -Ensure 'Present' `
                                                  -EnvironmentName 'Production' `
                                                  -OctopusCredentials $creds `
-                                                 -OctopusApiKey $creds } | should throw "Please provide either 'OctopusCredentials' or 'OctopusApiKey', not both."
+                                                 -OctopusApiKey $creds } | Should -throw "Please provide either 'OctopusCredentials' or 'OctopusApiKey', not both."
                 }
 
                 It 'Throws when neither OctopusCredentials and OctopusApiKey are provided' {
                     {Get-TargetResource -Url 'https://octopus.example.com' `
                                                  -Ensure 'Present' `
-                                                 -EnvironmentName 'Production'} | should throw "Please provide either 'OctopusCredentials' or 'OctopusApiKey'."
+                                                 -EnvironmentName 'Production'} | Should -throw "Please provide either 'OctopusCredentials' or 'OctopusApiKey'."
                 }
             }
 
@@ -55,7 +55,7 @@ try
                                                  -Ensure 'Present' `
                                                  -EnvironmentName 'Production' `
                                                  -OctopusCredentials $creds
-                    $result.Ensure | should be 'Present'
+                    $result.Ensure | Should -Be 'Present'
                 }
             }
 
@@ -66,13 +66,15 @@ try
                                                  -Ensure 'Present' `
                                                  -EnvironmentName 'Production' `
                                                  -OctopusCredentials $creds
-                    $result.Ensure | should be 'Absent'
+                    $result.Ensure | Should -Be 'Absent'
                 }
             }
 
             Context 'Test-TargetResource' {
-                $response = @{  }
-                Mock Get-TargetResource { return $response }
+                BeforeAll {
+                    $response = @{  }
+                    Mock Get-TargetResource { return $response }
+                }
 
                 It 'Returns false if environment does not exist' {
                     $password = ConvertTo-SecureString "1a2b3c4d5e6f" -AsPlainText -Force
@@ -88,7 +90,7 @@ try
                     $response['EnvironmentName'] = $null
                     $response['OctopusCredentials'] = $creds
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns true if environment does exist' {
@@ -105,7 +107,7 @@ try
                     $response['EnvironmentName'] = 'Production'
                     $response['OctopusCredentials'] = $creds
 
-                    Test-TargetResource @desiredConfiguration | Should Be $true
+                    Test-TargetResource @desiredConfiguration | Should -Be $true
                 }
 
                 It 'Calls Get-TargetResource (and therefore inherits its checks)' {

--- a/OctopusDSC/Tests/cOctopusSeqLogger.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusSeqLogger.Tests.ps1
@@ -13,8 +13,10 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
-        $sampleConfigPath = Split-Path $PSCommandPath -Parent
-        $sampleConfigPath = Join-Path $sampleConfigPath "SampleConfigs"
+        BeforeAll {
+            $sampleConfigPath = Split-Path $PSCommandPath -Parent
+            $sampleConfigPath = Join-Path $sampleConfigPath "SampleConfigs"
+        }
 
         Describe 'cOctopusSeqLogger' {
             BeforeEach {
@@ -40,13 +42,13 @@ try
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
 
                     $config = Get-TargetResourceInternal @desiredConfiguration
-                    $config.ConfigVersion                             | Should Be 2
-                    $config.InstanceType                              | Should Be 'OctopusServer'
-                    $config.Ensure                                    | Should Be 'Present'
-                    $config.SeqServer                                 | Should Be 'https://seq.example.com'
-                    $config.SeqApiKey.GetNetworkCredential().Password | Should Be '1a2b3c4d5e6f'
-                    $config.Properties['Application']                 | Should Be $desiredConfiguration.Properties['Application']
-                    $config.Properties['Server']                      | Should Be $desiredConfiguration.Properties['Server']
+                    $config.ConfigVersion                             | Should -Be 2
+                    $config.InstanceType                              | Should -Be 'OctopusServer'
+                    $config.Ensure                                    | Should -Be 'Present'
+                    $config.SeqServer                                 | Should -Be 'https://seq.example.com'
+                    $config.SeqApiKey.GetNetworkCredential().Password | Should -Be '1a2b3c4d5e6f'
+                    $config.Properties['Application']                 | Should -Be $desiredConfiguration.Properties['Application']
+                    $config.Properties['Server']                      | Should -Be $desiredConfiguration.Properties['Server']
                 }
 
                 It 'Returns expected data for old sync config' {
@@ -56,13 +58,13 @@ try
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-old-sync-configuration-with-api-key.xml")) }
 
                     $config = Get-TargetResourceInternal @desiredConfiguration
-                    $config.ConfigVersion                             | Should Be 1
-                    $config.InstanceType                              | Should Be 'OctopusServer'
-                    $config.Ensure                                    | Should Be 'Present'
-                    $config.SeqServer                                 | Should Be 'https://seq.example.com'
-                    $config.SeqApiKey.GetNetworkCredential().Password | Should Be '1a2b3c4d5e6f'
-                    $config.Properties['Application']                 | Should Be $desiredConfiguration.Properties['Application']
-                    $config.Properties['Server']                      | Should Be $desiredConfiguration.Properties['Server']
+                    $config.ConfigVersion                             | Should -Be 1
+                    $config.InstanceType                              | Should -Be 'OctopusServer'
+                    $config.Ensure                                    | Should -Be 'Present'
+                    $config.SeqServer                                 | Should -Be 'https://seq.example.com'
+                    $config.SeqApiKey.GetNetworkCredential().Password | Should -Be '1a2b3c4d5e6f'
+                    $config.Properties['Application']                 | Should -Be $desiredConfiguration.Properties['Application']
+                    $config.Properties['Server']                      | Should -Be $desiredConfiguration.Properties['Server']
                 }
 
                 It 'Returns expected data when config not set' {
@@ -72,11 +74,11 @@ try
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-when-not-configured.xml")) }
 
                     $config = Get-TargetResourceInternal @desiredConfiguration
-                    $config.InstanceType     | Should Be 'OctopusServer'
-                    $config.Ensure           | Should Be 'Absent'
-                    $config.SeqServer        | Should Be $null
-                    $config.SeqApiKey        | Should Be $null
-                    $config.Properties.Count | Should Be 0
+                    $config.InstanceType     | Should -Be 'OctopusServer'
+                    $config.Ensure           | Should -Be 'Absent'
+                    $config.SeqServer        | Should -Be $null
+                    $config.SeqApiKey        | Should -Be $null
+                    $config.Properties.Count | Should -Be 0
                 }
 
                 It 'Returns expected data when dll does not exist' {
@@ -86,12 +88,12 @@ try
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
 
                     $config = Get-TargetResourceInternal @desiredConfiguration
-                    $config.InstanceType                              | Should Be 'OctopusServer'
-                    $config.Ensure                                    | Should Be 'Absent'
-                    $config.SeqServer                                 | Should Be 'https://seq.example.com'
-                    $config.SeqApiKey.GetNetworkCredential().Password | Should Be '1a2b3c4d5e6f'
-                    $config.Properties['Application']                 | Should Be $desiredConfiguration.Properties['Application']
-                    $config.Properties['Server']                      | Should Be $desiredConfiguration.Properties['Server']
+                    $config.InstanceType                              | Should -Be 'OctopusServer'
+                    $config.Ensure                                    | Should -Be 'Absent'
+                    $config.SeqServer                                 | Should -Be 'https://seq.example.com'
+                    $config.SeqApiKey.GetNetworkCredential().Password | Should -Be '1a2b3c4d5e6f'
+                    $config.Properties['Application']                 | Should -Be $desiredConfiguration.Properties['Application']
+                    $config.Properties['Server']                      | Should -Be $desiredConfiguration.Properties['Server']
                 }
 
                 It 'Throws an exception if Octopus is not installed and ensure is set to present' {
@@ -99,7 +101,7 @@ try
                     Mock Test-Path { return $false } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
-                    { Get-TargetResourceInternal @desiredConfiguration } | Should Throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResourceInternal @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
                 }
 
                 It 'Does not throw an exception if Octopus is not installed and ensure is set to absent' {
@@ -108,13 +110,15 @@ try
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
                     $desiredConfiguration.Ensure = 'Absent'
-                    { Get-TargetResourceInternal @desiredConfiguration } | Should Not Throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResourceInternal @desiredConfiguration } | Should -not -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
                 }
             }
 
             Context 'Test-TargetResource' {
-                $response = @{ InstanceType="OctopusServer"; Ensure='Present' }
-                Mock Get-TargetResourceInternal { return $response }
+                BeforeAll {
+                    $response = @{ InstanceType="OctopusServer"; Ensure='Present' }
+                    Mock Get-TargetResourceInternal { return $response }
+                }
 
                 It 'Returns True when its got the expected values' {
                     $desiredPassword = ConvertTo-SecureString "1a2b3c4d5e6f" -AsPlainText -Force
@@ -135,7 +139,7 @@ try
                     $response['SeqApiKey'] = $actualApiKey
                     $response['Properties'] = @{ Application = "Octopus"; Server = "MyServer" }
 
-                    Test-TargetResourceInternal @desiredConfiguration | Should Be $true
+                    Test-TargetResourceInternal @desiredConfiguration | Should -Be $true
                 }
 
                 It 'Returns false when there are a different number of properties' {
@@ -157,7 +161,7 @@ try
                     $response['SeqApiKey'] = $actualApiKey
                     $response['Properties'] = @{ Application = "Octopus"; Server = "MyServer"; AnotherProperty = "PropertyValue" }
 
-                    Test-TargetResourceInternal @desiredConfiguration | Should Be $false
+                    Test-TargetResourceInternal @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false when there the properties have different names' {
@@ -179,7 +183,7 @@ try
                     $response['SeqApiKey'] = $actualApiKey
                     $response['Properties'] = @{ Application = "Octopus"; AnotherProperty = "MyServer" }
 
-                    Test-TargetResourceInternal @desiredConfiguration | Should Be $false
+                    Test-TargetResourceInternal @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false when there the properties have different values' {
@@ -201,7 +205,7 @@ try
                     $response['SeqApiKey'] = $actualApiKey
                     $response['Properties'] = @{ Application = "Octopus"; Server = "MyDifferemtServer" }
 
-                    Test-TargetResourceInternal @desiredConfiguration | Should Be $false
+                    Test-TargetResourceInternal @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false when the api key is different' {
@@ -223,7 +227,7 @@ try
                     $response['SeqApiKey'] = $actualApiKey
                     $response['Properties'] = @{ Application = "Octopus"; Server = "MyServer" }
 
-                    Test-TargetResourceInternal @desiredConfiguration | Should Be $false
+                    Test-TargetResourceInternal @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false when the server is different' {
@@ -245,7 +249,7 @@ try
                     $response['SeqApiKey'] = $actualApiKey
                     $response['Properties'] = @{ Application = "Octopus"; Server = "MyServer" }
 
-                    Test-TargetResourceInternal @desiredConfiguration | Should Be $false
+                    Test-TargetResourceInternal @desiredConfiguration | Should -Be $false
                 }
 
                It 'Returns false when its currently disabled and installation requested' {
@@ -264,7 +268,7 @@ try
                     $response['SeqApiKey'] = $null
                     $response['Properties'] = @{ }
 
-                    Test-TargetResourceInternal @desiredConfiguration | Should Be $false
+                    Test-TargetResourceInternal @desiredConfiguration | Should -Be $false
                 }
 
                It 'Returns false when its currently enabled and removal requested' {
@@ -283,7 +287,7 @@ try
                     $response['SeqApiKey'] = $actualApiKey
                     $response['Properties'] = @{ Application = "Octopus"; Server = "MyServer" }
 
-                    Test-TargetResourceInternal @desiredConfiguration | Should Be $false
+                    Test-TargetResourceInternal @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Calls Get-TargetResource (and therefore inherits its checks)' {
@@ -311,7 +315,7 @@ try
                     $response['Properties'] = @{ Application = "Octopus"; Server = "MyServer" }
                     $response['ConfifVersion'] = 1
 
-                    Test-TargetResourceInternal @desiredConfiguration | Should Be $false
+                    Test-TargetResourceInternal @desiredConfiguration | Should -Be $false
                 }
             }
 
@@ -345,7 +349,7 @@ try
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
                     $expected = [xml](Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-when-not-configured.xml"))
 
-                    Mock Save-NlogConfig { $nlogConfig.OuterXml | Should be $expected.OuterXml }
+                    Mock Save-NlogConfig { $nlogConfig.OuterXml | Should -Be $expected.OuterXml }
 
                     #call the internal one, as we cant figure out how to mock the ciminstance
                     Set-TargetResourceInternal -InstanceType 'OctopusServer' -Ensure 'Absent'
@@ -363,7 +367,7 @@ try
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-old-sync-configuration-with-api-key.xml")) }
                     $expected = [xml](Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-when-not-configured.xml"))
 
-                    Mock Save-NlogConfig { $nlogConfig.OuterXml | Should be $expected.OuterXml }
+                    Mock Save-NlogConfig { $nlogConfig.OuterXml | Should -Be $expected.OuterXml }
 
                     #call the internal one, as we cant figure out how to mock the ciminstance
                     Set-TargetResourceInternal -InstanceType 'OctopusServer' -Ensure 'Absent'
@@ -394,7 +398,7 @@ try
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-when-not-configured.xml")) }
                     $expected = [xml](Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration.xml"))
 
-                    Mock Save-NlogConfig { $nlogConfig.OuterXml | Should be $expected.OuterXml }
+                    Mock Save-NlogConfig { $nlogConfig.OuterXml | Should -Be $expected.OuterXml }
 
                     #call the internal one, as we cant figure out how to mock the ciminstance
                     Set-TargetResourceInternal -InstanceType 'OctopusServer' `
@@ -413,7 +417,7 @@ try
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-when-not-configured.xml")) }
                     $expected = [xml](Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml"))
 
-                    Mock Save-NlogConfig { $nlogConfig.OuterXml | Should be $expected.OuterXml }
+                    Mock Save-NlogConfig { $nlogConfig.OuterXml | Should -Be $expected.OuterXml }
                     $password = ConvertTo-SecureString "1a2b3c4d5e6f" -AsPlainText -Force
                     $apiKey = New-Object System.Management.Automation.PSCredential ("ignored", $password)
 
@@ -435,7 +439,7 @@ try
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-old-sync-configuration-with-api-key.xml")) }
                     $expected = [xml](Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml"))
 
-                    Mock Save-NlogConfig { $nlogConfig.OuterXml | Should be $expected.OuterXml }
+                    Mock Save-NlogConfig { $nlogConfig.OuterXml | Should -Be $expected.OuterXml }
                     $password = ConvertTo-SecureString "1a2b3c4d5e6f" -AsPlainText -Force
                     $apiKey = New-Object System.Management.Automation.PSCredential ("ignored", $password)
 
@@ -457,7 +461,7 @@ try
                     Mock Save-NlogConfig
 
                     #call the internal one, as we cant figure out how to mock the ciminstance
-                    { Set-TargetResourceInternal -InstanceType 'OctopusServer' -Ensure 'Present' } | Should Throw "Property 'SeqServer' should be supplied if 'Ensure' is set to 'Present'"
+                    { Set-TargetResourceInternal -InstanceType 'OctopusServer' -Ensure 'Present' } | Should -throw "Property 'SeqServer' should be supplied if 'Ensure' is set to 'Present'"
                 }
             }
         }

--- a/OctopusDSC/Tests/cOctopusServer.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServer.Tests.ps1
@@ -456,7 +456,7 @@ try
 
                 Context "New instance" {
                     BeforeAll {
-                        Mock Invoke-OctopusServerCommand {} #{write-host $args}
+                        Mock Invoke-OctopusServerCommand {} #{write-host $cmdArgs}
                         Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstance" }
                         Mock Get-RegistryValue { return "478389" } # checking .net 4.5
                         Mock Invoke-MsiExec {}
@@ -484,7 +484,7 @@ try
 
                 Context "New instance with metrics" {
                     BeforeAll {
-                        Mock Invoke-OctopusServerCommand #{write-host $args}
+                        Mock Invoke-OctopusServerCommand #{write-host $cmdArgs}
                         Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstanceWithMetrics" }
                         Mock Get-RegistryValue { return "478389" } # checking .net 4.5
                         Mock Invoke-MsiExec {}
@@ -510,7 +510,7 @@ try
 
                 Context "When MasterKey is supplied on new instance" {
                     BeforeAll {
-                        Mock Invoke-OctopusServerCommand #{write-host $args}
+                        Mock Invoke-OctopusServerCommand #{write-host $cmdArgs}
                         Mock Get-TargetResource { return Get-CurrentConfiguration "MasterKeySupplied" }
                         Mock Get-RegistryValue { return "478389" } # checking .net 4.5
                         Mock Invoke-MsiExec {}
@@ -536,7 +536,7 @@ try
 
                 Context "When uninstalling running instance" {
                     BeforeAll {
-                        Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
+                        Mock Invoke-OctopusServerCommand #{ param ($cmdArgs) write-host $cmdArgs}
                         Mock Get-TargetResource { return Get-CurrentConfiguration "UninstallingRunningInstance" }
                         Mock Invoke-MsiExec {}
                         Mock Get-LogDirectory {}
@@ -565,7 +565,7 @@ try
 
                 Context "Run-on-server user - new install" {
                     BeforeAll {
-                        Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
+                        Mock Invoke-OctopusServerCommand #{ param ($cmdArgs) write-host $cmdArgs}
                         Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstallWithBuiltInWorker" }
                         Mock Get-RegistryValue { return "478389" } # checking .net 4.5
                         Mock Invoke-MsiExec {}
@@ -592,7 +592,7 @@ try
 
                 Context "Run-on-server user - existing install" {
                     BeforeAll {
-                        Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
+                        Mock Invoke-OctopusServerCommand #{ param ($cmdArgs) write-host $cmdArgs}
                         Mock Get-TargetResource { return Get-CurrentConfiguration "EnableBuiltInWorkerOnExistingInstance" }
                         Mock Get-RegistryValue { return "478389" } # checking .net 4.5
                         Mock Invoke-MsiExec {}
@@ -646,7 +646,7 @@ try
 
                 Context "Change WebListenPrefix" {
                     BeforeAll {
-                        Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
+                        Mock Invoke-OctopusServerCommand #{ param ($cmdArgs) write-host $cmdArgs}
                         Mock Get-TargetResource { return Get-CurrentConfiguration "ChangeWebListenPrefix" }
                         Mock Get-RegistryValue { return "478389" } # checking .net 4.5
                         Mock Invoke-MsiExec {}

--- a/OctopusDSC/Tests/cOctopusServer.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServer.Tests.ps1
@@ -26,7 +26,10 @@ try
                 # Get-Service is not available on mac/unix systems - fake it
                 $getServiceCommand = Get-Command "Get-Service" -ErrorAction SilentlyContinue
                 if ($null -eq $getServiceCommand) {
-                    function Get-Service {}
+                    function Get-Service {
+                        [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidOverwritingBuiltInCmdlets', '', Justification='Get-Service is not available on mac/unix systems, so without faking it, our builds fail')]
+                        param()
+                    }
                 }
 
                 function Get-DesiredConfiguration {
@@ -441,10 +444,10 @@ try
                     it "Should call octopus.server.exe $($invocations.count) times" {
                         Assert-MockCalled -CommandName 'Invoke-OctopusServerCommand' -Times $invocations.Count -Exactly
                     }
-                    if ($cases.length -gt 0)
-                    {
+                    if ($cases.length -gt 0) {
                         it "Should call octopus.server.exe with args '<line>'" -TestCases $cases {
                             param($line)
+                            write-verbose "Checking line $line" # workaround ReviewUnusedParameter does not capture parameter usage within a scriptblock.  See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472
                             Set-TargetResource @params
                             Assert-MockCalled -CommandName 'Invoke-OctopusServerCommand' -Times 1 -Exactly -ParameterFilter { ($cmdArgs -join ' ') -eq $line }
                         }

--- a/OctopusDSC/Tests/cOctopusServer.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServer.Tests.ps1
@@ -619,7 +619,7 @@ try
 
                 Context "Upgrade" {
                     BeforeAll {
-                        Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
+                        Mock Invoke-OctopusServerCommand #{ param ($cmdArgs) write-host $cmdArgs}
                         Mock Get-TargetResource { return Get-CurrentConfiguration "UpgradeExistingInstance" }
                         Mock Get-RegistryValue { return "478389" } # checking .net 4.5
                         Mock Invoke-MsiExec {}

--- a/OctopusDSC/Tests/cOctopusServer.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServer.Tests.ps1
@@ -4,6 +4,7 @@ param()
 
 $moduleName = Split-Path ($PSCommandPath -replace '\.Tests\.ps1$', '') -Leaf
 $modulePath = Resolve-Path "$PSCommandPath/../../DSCResources/$moduleName/$moduleName.psm1"
+$global:powershellHelpersPath = Resolve-Path "$PSCommandPath/../../../tests/powershell-helpers.ps1"
 $module = $null
 
 try
@@ -21,12 +22,13 @@ try
         }
 
         Describe 'cOctopusServer' {
-            [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
-            $mockConfig = [pscustomobject] @{
-                OctopusStorageExternalDatabaseConnectionString         = 'StubConnectionString'
-                OctopusWebPortalListenPrefixes                         = "https://octopus.example.com,http://localhost"
-            }
-            Mock Import-ServerConfig { return $mockConfig }
+            BeforeAll {
+                [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+                $mockConfig = [pscustomobject] @{
+                    OctopusStorageExternalDatabaseConnectionString         = 'StubConnectionString'
+                    OctopusWebPortalListenPrefixes                         = "https://octopus.example.com,http://localhost"
+                }
+                Mock Import-ServerConfig { return $mockConfig }
 
             function Get-DesiredConfiguration {
                 $pass = ConvertTo-SecureString "S3cur3P4ssphraseHere!" -AsPlainText -Force
@@ -34,98 +36,81 @@ try
 
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
                 $desiredConfiguration = @{
-                     Name                   = 'Stub'
-                     Ensure                 = 'Present'
-                     State                  = 'Started'
-                     WebListenPrefix        = "http://localhost:80"
-                     SqlDbConnectionString  = "conn-string"
-                     OctopusAdminCredential = $cred
+                    Name                   = 'Stub'
+                    Ensure                 = 'Present'
+                    State                  = 'Started'
+                    WebListenPrefix        = "http://localhost:80"
+                    SqlDbConnectionString  = "conn-string"
+                    OctopusAdminCredential = $cred
                 }
                 return $desiredConfiguration
             }
+        }
 
             Context 'Get-TargetResource' {
                 Context 'When reg key exists and service exists and service started' {
-                    Mock Get-ItemProperty { return @{ InstallLocation = "c:\Octopus\Octopus" }}
-                    Mock Get-Service { return @{ Status = "Running" }}
-                    $desiredConfiguration = Get-DesiredConfiguration
-                    $config = Get-TargetResource @desiredConfiguration
-
-                    It 'Should have Ensure=Present' {
-                        $config['Ensure']                  | Should Be 'Present'
-                    }
-                    It 'Should have State=Started' {
-                        $config['State']                   | Should Be 'Started'
+                    It 'Should have Ensure=Present and State=Started' {
+                        Mock Get-ItemProperty { return @{ InstallLocation = "c:\Octopus\Octopus" }}
+                        Mock Get-Service { return @{ Status = "Running" }}
+                        $desiredConfiguration = Get-DesiredConfiguration
+                        $config = Get-TargetResource @desiredConfiguration
+                        $config['Ensure']                  | Should -Be 'Present'
+                        $config['State']                   | Should -Be 'Started'
                     }
                 }
 
                 Context 'When reg key exists and service exists and service stopped' {
-                    Mock Get-ItemProperty { return @{ InstallLocation = "c:\Octopus\Octopus" }}
-                    Mock Get-Service { return @{ Status = "Stopped" }}
-                    $desiredConfiguration = Get-DesiredConfiguration
-                    $config = Get-TargetResource @desiredConfiguration
-
-                    It 'Should have Ensure=Present' {
-                        $config['Ensure']                  | Should Be 'Present'
-                    }
-                    It 'Should have State=Stopped' {
-                        $config['State']                   | Should Be 'Stopped'
+                    It 'Should have Ensure=Present and State=Stopped' {
+                        Mock Get-ItemProperty { return @{ InstallLocation = "c:\Octopus\Octopus" }}
+                        Mock Get-Service { return @{ Status = "Stopped" }}
+                        $desiredConfiguration = Get-DesiredConfiguration
+                        $config = Get-TargetResource @desiredConfiguration
+                        $config['Ensure']                  | Should -Be 'Present'
+                        $config['State']                   | Should -Be 'Stopped'
                     }
                 }
 
                 Context 'When reg key exists and service does not exist' {
-                    Mock Get-ItemProperty { return @{ InstallLocation = "c:\Octopus\Octopus" }}
-                    Mock Get-Service { return $null }
-                    $desiredConfiguration = Get-DesiredConfiguration
-                    $config = Get-TargetResource @desiredConfiguration
-
-                    It 'Should have Ensure=Present' {
-                        $config['Ensure']                  | Should Be 'Present'
-                    }
-                    It 'Should have State=Installed' {
-                        $config['State']                   | Should Be 'Installed'
+                    It 'Should have Ensure=Present and State=Installed' {
+                        Mock Get-ItemProperty { return @{ InstallLocation = "c:\Octopus\Octopus" }}
+                        Mock Get-Service { return $null }
+                        $desiredConfiguration = Get-DesiredConfiguration
+                        $config = Get-TargetResource @desiredConfiguration
+                        $config['Ensure']                  | Should -Be 'Present'
+                        $config['State']                   | Should -Be 'Installed'
                     }
                 }
 
                 Context 'When reg key does not exist and service does not exist' {
-                    Mock Get-ItemProperty { return $null }
-                    Mock Get-Service { return $null }
-                    $desiredConfiguration = Get-DesiredConfiguration
-                    $config = Get-TargetResource @desiredConfiguration
-
-                    It 'Should have Ensure=Absent' {
-                        $config['Ensure']                  | Should Be 'Absent'
-                    }
-                    It 'Should have State=Stopped' {
-                        $config['State']                   | Should Be 'Stopped'
+                    It 'Should have Ensure=Absent and State=Stopped' {
+                        Mock Get-ItemProperty { return $null }
+                        Mock Get-Service { return $null }
+                        $desiredConfiguration = Get-DesiredConfiguration
+                        $config = Get-TargetResource @desiredConfiguration
+                        $config['Ensure']                  | Should -Be 'Absent'
+                        $config['State']                   | Should -Be 'Stopped'
                     }
                 }
 
                 Context 'When reg key does not exist and service started' {
-                    Mock Get-ItemProperty { return $null }
-                    Mock Get-Service { return @{ Status = "Running" } }
-                    $desiredConfiguration = Get-DesiredConfiguration
-                    $config = Get-TargetResource @desiredConfiguration
-
-                    It 'Should have Ensure=Present' {
-                        $config['Ensure']                  | Should Be 'Present'
-                    }
-                    It 'Should have State=Started' {
-                        $config['State']                   | Should Be 'Started'
+                    It 'Should have Ensure=Present and State=Started' {
+                        Mock Get-ItemProperty { return $null }
+                        Mock Get-Service { return @{ Status = "Running" } }
+                        $desiredConfiguration = Get-DesiredConfiguration
+                        $config = Get-TargetResource @desiredConfiguration
+                        $config['Ensure']                  | Should -Be 'Present'
+                        $config['State']                   | Should -Be 'Started'
                     }
                 }
 
                 Context 'When reg key does not exist and service stopped' {
-                    Mock Get-ItemProperty { return $null }
-                    Mock Get-Service { return @{ Status = "Stopped" } }
-                    $desiredConfiguration = Get-DesiredConfiguration
-                    $config = Get-TargetResource @desiredConfiguration
-
-                    It 'Should have Ensure=Present' {
-                        $config['Ensure']                  | Should Be 'Present'
-                    }
-                    It 'Should have State=Stopped' {
-                        $config['State']                   | Should Be 'Stopped'
+                    It 'Should have Ensure=Present and State=Stopped' {
+                        Mock Get-ItemProperty { return $null }
+                        Mock Get-Service { return @{ Status = "Stopped" } }
+                        $desiredConfiguration = Get-DesiredConfiguration
+                        $config = Get-TargetResource @desiredConfiguration
+                        $config['Ensure']                  | Should -Be 'Present'
+                        $config['State']                   | Should -Be 'Stopped'
                     }
                 }
             }
@@ -133,206 +118,217 @@ try
             Context "Parameter Validation" {
                 Context "Ensure = 'Present' and 'State' = 'Stopped'" {
                     It "Should throw if 'Name' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -DownloadUrl "blah2" } | Should throw "Parameter 'Name' must be supplied when 'Ensure' is 'Present'."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -DownloadUrl "blah2" } `
+                            | Should -throw "Parameter 'Name' must be supplied when 'Ensure' is 'Present'."
                     }
                     It "Should throw if 'DownloadUrl' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" } | Should throw "Parameter 'DownloadUrl' must be supplied when 'Ensure' is 'Present'."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" } `
+                            | Should -throw "Parameter 'DownloadUrl' must be supplied when 'Ensure' is 'Present'."
                     }
                     It "Should throw if 'WebListenPrefix' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" } | Should throw "Parameter 'WebListenPrefix' must be supplied when 'Ensure' is 'Present'."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" } `
+                            | Should -throw "Parameter 'WebListenPrefix' must be supplied when 'Ensure' is 'Present'."
                     }
                     It "Should throw if 'SqlDbConnectionString' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3"} | Should throw "Parameter 'SqlDbConnectionString' must be supplied when 'Ensure' is 'Present'."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3"} `
+                            | Should -throw "Parameter 'SqlDbConnectionString' must be supplied when 'Ensure' is 'Present'."
                     }
                     It "Should throw if 'TaskCap' is less than 1" {
                         $creds = New-Object System.Management.Automation.PSCredential ("username", (new-object System.Security.SecureString))
-                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds -TaskCap -1} | Should throw "Parameter 'TaskCap' must be greater than 0 when 'Ensure' is 'Present'."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds -TaskCap -1} `
+                            | Should -throw "Parameter 'TaskCap' must be greater than 0 when 'Ensure' is 'Present'."
                     }
                     It "Should throw if 'TaskCap' is greater than 50" {
                         $creds = New-Object System.Management.Automation.PSCredential ("username", (new-object System.Security.SecureString))
-                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds -TaskCap 51} | Should throw "Parameter 'TaskCap' must be less than 50 when 'Ensure' is 'Present'."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds -TaskCap 51} `
+                            | Should -throw "Parameter 'TaskCap' must be less than 50 when 'Ensure' is 'Present'."
                     }
                     It "Should not throw if 'OctopusAdminCredential' not supplied but 'OctopusMasterKey' is supplied" {
                         $creds = New-Object System.Management.Automation.PSCredential ("username", (new-object System.Security.SecureString))
-                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null -OctopusMasterKey $creds} | Should not throw
+                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null -OctopusMasterKey $creds} | Should -not -throw
                     }
                     It "Should not throw if 'OctopusAdminCredential' is '[PSCredential]::Empty' but 'OctopusMasterKey' is supplied" {
                         $creds = New-Object System.Management.Automation.PSCredential ("username", (new-object System.Security.SecureString))
-                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusMasterKey $creds} | Should not throw
+                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusMasterKey $creds} | Should -not -throw
                     }
                     It "Should throw if 'OctopusAdminCredential' not supplied and 'OctopusMasterKey' is not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" } | Should throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" } `
+                            | Should -throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
                     }
                     It "Should throw if 'OctopusAdminCredential' is null and 'OctopusMasterKey' is null" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null -OctopusMasterKey $null } | Should throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null -OctopusMasterKey $null } `
+                            | Should -throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
                     }
                     It "Should throw if 'OctopusAdminCredential' is '[PSCredential]::Empty' and 'OctopusMasterKey' is '[PSCredential]::Empty'" {
                         $creds = [PSCredential]::Empty
                         $masterKey = [PSCredential]::Empty
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds -OctopusMasterKey $masterKey } | Should throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds -OctopusMasterKey $masterKey } `
+                            | Should -throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
                     }
                     It "Should not throw if all params are supplied" {
                         $creds = New-Object System.Management.Automation.PSCredential ("username", (new-object System.Security.SecureString))
-                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds} | Should not throw
+                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds} | Should -not -throw
                     }
                 }
 
                 Context "Ensure = 'Present' and 'State' = 'Started'" {
                     It "Should throw if 'Name' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -DownloadUrl "blah2" } | Should throw "Parameter 'Name' must be supplied when 'Ensure' is 'Present'."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Stopped' -DownloadUrl "blah2" } | Should -throw "Parameter 'Name' must be supplied when 'Ensure' is 'Present'."
                     }
                     It "Should throw if 'DownloadUrl' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" } | Should throw "Parameter 'DownloadUrl' must be supplied when 'Ensure' is 'Present'."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" } | Should -throw "Parameter 'DownloadUrl' must be supplied when 'Ensure' is 'Present'."
                     }
                     It "Should throw if 'WebListenPrefix' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" } | Should throw "Parameter 'WebListenPrefix' must be supplied when 'Ensure' is 'Present'."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" } | Should -throw "Parameter 'WebListenPrefix' must be supplied when 'Ensure' is 'Present'."
                     }
                     It "Should throw if 'SqlDbConnectionString' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3"} | Should throw "Parameter 'SqlDbConnectionString' must be supplied when 'Ensure' is 'Present'."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3"} | Should -throw "Parameter 'SqlDbConnectionString' must be supplied when 'Ensure' is 'Present'."
                     }
                     It "Should not throw if 'OctopusAdminCredential' not supplied but 'OctopusMasterKey' is supplied" {
                         $creds = New-Object System.Management.Automation.PSCredential ("username", (new-object System.Security.SecureString))
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null -OctopusMasterKey $creds} | Should not throw
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null -OctopusMasterKey $creds} | Should -not -throw
                     }
                     It "Should not throw if 'OctopusAdminCredential' is '[PSCredential]::Empty' but 'OctopusMasterKey' is supplied" {
                         $creds = New-Object System.Management.Automation.PSCredential ("username", (new-object System.Security.SecureString))
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusMasterKey $creds} | Should not throw
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusMasterKey $creds} | Should -not -throw
                     }
                     It "Should throw if 'OctopusAdminCredential' not supplied and 'OctopusMasterKey' is not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" } | Should throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" } | Should -throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
                     }
                     It "Should throw if 'OctopusAdminCredential' is null and 'OctopusMasterKey' is null" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null -OctopusMasterKey $null } | Should throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null -OctopusMasterKey $null } | Should -throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
                     }
                     It "Should throw if 'OctopusAdminCredential' is '[PSCredential]::Empty' and 'OctopusMasterKey' is '[PSCredential]::Empty'" {
                         $creds = [PSCredential]::Empty
                         $masterKey = [PSCredential]::Empty
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds -OctopusMasterKey $masterKey } | Should throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds -OctopusMasterKey $masterKey } | Should -throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
                     }
                     It "Should not throw if all params are supplied" {
                         $creds = New-Object System.Management.Automation.PSCredential ("username", (new-object System.Security.SecureString))
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds} | Should not throw
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds} | Should -not -throw
                     }
                 }
 
                 Context "Ensure = 'Present' and 'State' = 'Installed'" {
                     It "Should not throw if 'Name' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' -DownloadUrl "blah2" } | Should not throw
+                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' -DownloadUrl "blah2" } | Should -not -throw
                     }
                     It "Should throw if 'DownloadUrl' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' } | Should throw "Parameter 'DownloadUrl' must be supplied when 'Ensure' is 'Present'."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' } | Should -throw "Parameter 'DownloadUrl' must be supplied when 'Ensure' is 'Present'."
                     }
                     It "Should not throw if 'WebListenPrefix' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' -DownloadUrl "blah2" } | Should not throw
+                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' -DownloadUrl "blah2" } | Should -not -throw
                     }
                     It "Should not throw if 'SqlDbConnectionString' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' -DownloadUrl "blah2" -WebListenPrefix "blah3"} | Should not throw
+                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' -DownloadUrl "blah2" -WebListenPrefix "blah3"} | Should -not -throw
                     }
                     It "Should not throw if 'OctopusAdminCredential' not supplied and 'SqlDbConnectionString' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' -DownloadUrl "blah2" -WebListenPrefix "blah3" -OctopusAdminCredential $null } | Should not throw
+                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' -DownloadUrl "blah2" -WebListenPrefix "blah3" -OctopusAdminCredential $null } | Should -not -throw
                     }
                     It "Should not throw if 'OctopusAdminCredential' is '[PSCredential]::Empty' and 'SqlDbConnectionString' not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' -DownloadUrl "blah2" -WebListenPrefix "blah3" } | Should not throw
+                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' -DownloadUrl "blah2" -WebListenPrefix "blah3" } | Should -not -throw
                     }
                     It "Should not throw if all params are supplied" {
                         $creds = New-Object System.Management.Automation.PSCredential ("username", (new-object System.Security.SecureString))
-                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds} | Should not throw
+                        { Test-ParameterSet -Ensure 'Present' -State 'Installed' -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds} | Should -not -throw
                     }
                 }
 
                 Context "Ensure = 'Present', 'State' = 'Installed', and 'SqlDbConnectionString' != 'null or empty'" {
                     It "Should throw if 'OctopusAdminCredential' not supplied and 'OctopusMasterKey' is not supplied" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" } | Should throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" } | Should -throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
                     }
                     It "Should throw if 'OctopusAdminCredential' is null and 'OctopusMasterKey' is null" {
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null -OctopusMasterKey $null } | Should throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null -OctopusMasterKey $null } | Should -throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
                     }
                     It "Should throw if 'OctopusAdminCredential' is '[PSCredential]::Empty' and 'OctopusMasterKey' is '[PSCredential]::Empty'" {
                         $creds = [PSCredential]::Empty
                         $masterKey = [PSCredential]::Empty
-                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds -OctopusMasterKey $masterKey } | Should throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
+                        { Test-ParameterSet -Ensure 'Present' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds -OctopusMasterKey $masterKey } | Should -throw "Parameter 'OctopusAdminCredential' must be supplied when 'Ensure' is 'Present' and you have not supplied a master key to use an existing database."
                     }
                 }
 
                 Context "Ensure = 'Absent' and 'State' = 'Stopped'" {
                     It "Should throw if 'Name' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' } | Should throw "Parameter 'Name' must be supplied when 'Ensure' is 'Absent'."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' } | Should -throw "Parameter 'Name' must be supplied when 'Ensure' is 'Absent'."
                     }
                     It "Should not throw if 'DownloadUrl' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' -Name "blah1" } | Should not throw
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' -Name "blah1" } | Should -not -throw
                     }
                     It "Should not throw if 'WebListenPrefix' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" } | Should not throw
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" } | Should -not -throw
                     }
                     It "Should not throw if 'SqlDbConnectionString' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3"} | Should not throw
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3"} | Should -not -throw
                     }
                     It "Should not throw if 'OctopusAdminCredential' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null} | Should not throw
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null} | Should -not -throw
                     }
                     It "Should not throw if 'OctopusAdminCredential' is '[PSCredential]::Empty'" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4"} | Should not throw
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4"} | Should -not -throw
                     }
                     It "Should not throw if all params are supplied" {
                         $creds = New-Object System.Management.Automation.PSCredential ("username", (new-object System.Security.SecureString))
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds} | Should not throw
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Stopped' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds} | Should -not -throw
                     }
                 }
 
                 Context "Ensure = 'Absent' and 'State' = 'Started'" {
                     It "Should throw if 'Name' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' } | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' } | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
                     }
                     It "Should throw if 'DownloadUrl' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' -Name "blah1"} | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' -Name "blah1"} | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
                     }
                     It "Should throw if 'WebListenPrefix' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' -Name "blah1" -DownloadUrl "blah2" } | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' -Name "blah1" -DownloadUrl "blah2" } | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
                     }
                     It "Should throw if 'SqlDbConnectionString' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3"} | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3"} | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
                     }
                     It "Should throw if 'OctopusAdminCredential' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null} | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null} | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
                     }
                     It "Should throw if 'OctopusAdminCredential' is '[PSCredential]::Empty'" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4"} | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4"} | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
                     }
                     It "Should throw if all params are supplied" {
                         $creds = New-Object System.Management.Automation.PSCredential ("username", (new-object System.Security.SecureString))
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds} | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Started' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds} | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"."
                     }
                 }
 
                 Context "Ensure = 'Absent' and 'State' = 'Installed'" {
                     It "Should throw if 'Name' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' } | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' } | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
                     }
                     It "Should throw if 'DownloadUrl' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' -Name "blah1"} | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' -Name "blah1"} | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
                     }
                     It "Should throw if 'WebListenPrefix' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' -Name "blah1" -DownloadUrl "blah2" } | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' -Name "blah1" -DownloadUrl "blah2" } | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
                     }
                     It "Should throw if 'SqlDbConnectionString' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3"} | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3"} | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
                     }
                     It "Should throw if 'OctopusAdminCredential' not supplied" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null} | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $null} | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
                     }
                     It "Should throw if 'OctopusAdminCredential' is '[PSCredential]::Empty'" {
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4"} | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4"} | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
                     }
                     It "Should throw if all params are supplied" {
                         $creds = New-Object System.Management.Automation.PSCredential ("username", (new-object System.Security.SecureString))
-                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds} | Should throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
+                        { Test-ParameterSet -Ensure 'Absent' -State 'Installed' -Name "blah1" -DownloadUrl "blah2" -WebListenPrefix "blah3" -SqlDbConnectionString "blah4" -OctopusAdminCredential $creds} | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be installed at the same time. You probably want 'State = `"Stopped`"."
                     }
                 }
             }
 
             Context 'Test-TargetResource' {
-                $response = @{ Ensure="Absent"; State="Stopped" }
-                Mock Get-TargetResource { return $response }
+                BeforeAll {
+                    $response = @{ Ensure="Absent"; State="Stopped" }
+                    Mock Get-TargetResource { return $response }
+                }
 
                 It 'Returns True when Ensure is set to Absent and Instance does not exist' {
                     $desiredConfiguration = Get-DesiredConfiguration
@@ -341,7 +337,7 @@ try
                     $response['Ensure'] = 'Absent'
                     $response['State'] = 'Stopped'
 
-                    Test-TargetResource @desiredConfiguration | Should Be $true
+                    Test-TargetResource @desiredConfiguration | Should -Be $true
                 }
 
                It 'Returns True when Ensure is set to Present and Instance exists' {
@@ -351,7 +347,7 @@ try
                     $response['Ensure'] = 'Present'
                     $response['State'] = 'Started'
 
-                    Test-TargetResource @desiredConfiguration | Should Be $true
+                    Test-TargetResource @desiredConfiguration | Should -Be $true
                 }
             }
 
@@ -364,7 +360,7 @@ try
                     Mock Get-RegistryValue { return "" }
                     Mock Update-InstallState
                     $desiredConfiguration = Get-DesiredConfiguration
-                    { Set-TargetResource @desiredConfiguration } | Should throw "Octopus Server requires .NET 4.5.2. Please install it before attempting to install Octopus Server."
+                    { Set-TargetResource @desiredConfiguration } | Should -throw "Octopus Server requires .NET 4.5.2. Please install it before attempting to install Octopus Server."
                 }
 
                 It 'Throws an exception if .net 4.5.2 or above is not installed (only .net 4.5.0 installed)' {
@@ -375,7 +371,7 @@ try
                     Mock Get-RegistryValue { return "378389" } # .NET Framework 4.5
                     Mock Update-InstallState
                     $desiredConfiguration = Get-DesiredConfiguration
-                    { Set-TargetResource @desiredConfiguration } | Should throw "Octopus Server requires .NET 4.5.2. Please install it before attempting to install Octopus Server."
+                    { Set-TargetResource @desiredConfiguration } | Should -throw "Octopus Server requires .NET 4.5.2. Please install it before attempting to install Octopus Server."
                 }
 
                 It 'Throws an exception if .net 4.7.2 or above is not installed (no .net reg key found)' {
@@ -386,7 +382,7 @@ try
                     Mock Get-RegistryValue { return "" }
                     Mock Update-InstallState
                     $desiredConfiguration = Get-DesiredConfiguration
-                    { Set-TargetResource @desiredConfiguration } | Should throw "Octopus Server requires .NET 4.7.2. Please install it before attempting to install Octopus Server."
+                    { Set-TargetResource @desiredConfiguration } | Should -throw "Octopus Server requires .NET 4.7.2. Please install it before attempting to install Octopus Server."
                 }
 
                 It 'Throws an exception if .net 4.7.2 or above is not installed (only .net 4.6.2 installed)' {
@@ -397,217 +393,259 @@ try
                     Mock Get-RegistryValue { return "394802" } # .NET Framework 4.6.2 on Windows Server 2016
                     Mock Update-InstallState
                     $desiredConfiguration = Get-DesiredConfiguration
-                    { Set-TargetResource @desiredConfiguration } | Should throw "Octopus Server requires .NET 4.7.2. Please install it before attempting to install Octopus Server."
+                    { Set-TargetResource @desiredConfiguration } | Should -throw "Octopus Server requires .NET 4.7.2. Please install it before attempting to install Octopus Server."
                 }
             }
 
             Context "Octopus server command line" {
-                function Get-CurrentConfiguration ([string] $testName) {
-                    & (Resolve-Path "$PSCommandPath/../../Tests/OctopusServerExeInvocationFiles/$testName/CurrentState.ps1")
-                }
+                BeforeAll {
+                    . $global:dscHelpersPath
 
-                function Get-RequestedConfiguration ([string] $testName) {
-                    & (Resolve-Path "$PSCommandPath/../../Tests/OctopusServerExeInvocationFiles/$testName/RequestedState.ps1")
-                }
-
-                function Assert-ExpectedResult ([string] $testName) {
-                    # todo: test order of execution here
-                    $invocations = & (Resolve-Path "$PSCommandPath/../../Tests/OctopusServerExeInvocationFiles/$testName/ExpectedResult.ps1")
-                    it "Should call octopus.server.exe $($invocations.count) times" {
-                        Assert-MockCalled -CommandName 'Invoke-OctopusServerCommand' -Times $invocations.Count -Exactly
+                    function Get-CurrentConfiguration ([string] $testName) {
+                        & (Resolve-Path "$PSCommandPath/../../Tests/OctopusServerExeInvocationFiles/$testName/CurrentState.ps1")
                     }
-                    foreach($line in $invocations) {
-                        It "Should call octopus.server.exe with args '$line'" {
-                            Assert-MockCalled -CommandName 'Invoke-OctopusServerCommand' -Times 1 -Exactly -ParameterFilter { ($arguments -join ' ') -eq $line }
+
+                    function Get-RequestedConfiguration ([string] $testName) {
+                        & (Resolve-Path "$PSCommandPath/../../Tests/OctopusServerExeInvocationFiles/$testName/RequestedState.ps1")
+                    }
+
+                    function Get-TempFolder {
+                        if ("$($env:TmpDir)" -ne "") {
+                            return $env:TmpDir
+                        } else {
+                            return $env:Temp
                         }
                     }
                 }
 
-                function Get-TempFolder {
-                    if ("$($env:TmpDir)" -ne "") {
-                        return $env:TmpDir
-                    } else {
-                        return $env:Temp
+                function Assert-ExpectedResult ([string] $testName) {
+                . $global:powershellHelpersPath
+                    # todo: test order of execution here
+                    $invocations = & (Resolve-Path "$PSCommandPath/../../Tests/OctopusServerExeInvocationFiles/$testName/ExpectedResult.ps1")
+                    $name = @{label="line";expression={$_}};
+                    $cases = @($invocations | select-object -Property $name) | ConvertTo-HashTable
+                    it "Should call octopus.server.exe $($invocations.count) times" {
+                        Assert-MockCalled -CommandName 'Invoke-OctopusServerCommand' -Times $invocations.Count -Exactly
+                    }
+                    if ($cases.length -gt 0)
+                    {
+                        it "Should call octopus.server.exe with args '<line>'" -TestCases $cases {
+                            param($line)
+                            Set-TargetResource @params
+                            Assert-MockCalled -CommandName 'Invoke-OctopusServerCommand' -Times 1 -Exactly -ParameterFilter { ($cmdArgs -join ' ') -eq $line }
+                        }
                     }
                 }
 
                 Context "New instance" {
-                    Mock Invoke-OctopusServerCommand #{write-host $args}
-                    Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstance" }
-                    Mock Get-RegistryValue { return "478389" } # checking .net 4.5
-                    Mock Invoke-MsiExec {}
-                    Mock Get-LogDirectory {}
-                    Mock Request-File {}
-                    Mock Update-InstallState {}
-                    Mock Test-OctopusDeployServerResponding { return $true }
-                    Mock Test-OctopusVersionNewerThan { return $true } # just assume we're the most recent version
-                    Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
+                    BeforeAll {
+                        Mock Invoke-OctopusServerCommand {} #{write-host $args}
+                        Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstance" }
+                        Mock Get-RegistryValue { return "478389" } # checking .net 4.5
+                        Mock Invoke-MsiExec {}
+                        Mock Get-LogDirectory {}
+                        Mock Request-File {}
+                        Mock Update-InstallState {}
+                        Mock Test-OctopusDeployServerResponding { return $true }
+                        Mock Test-OctopusVersionNewerThan { return $true } # just assume we're the most recent version
+                        Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
 
-                    $params = Get-RequestedConfiguration "NewInstance"
-                    Set-TargetResource @params
-
+                        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
+                        $params = Get-RequestedConfiguration "NewInstance"
+                    }
                     Assert-ExpectedResult "NewInstance"
                     it "Should download the MSI" {
+                        Set-TargetResource @params
                         Assert-MockCalled Request-File
+                    }
+
+                    it "Should install the MSI" {
+                        Set-TargetResource @params
                         Assert-MockCalled Invoke-MsiExec
                     }
                 }
 
                 Context "New instance with metrics" {
-                    Mock Invoke-OctopusServerCommand #{write-host $args}
-                    Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstanceWithMetrics" }
-                    Mock Get-RegistryValue { return "478389" } # checking .net 4.5
-                    Mock Invoke-MsiExec {}
-                    Mock Get-LogDirectory {}
-                    Mock Request-File {}
-                    Mock Update-InstallState {}
-                    Mock Test-OctopusDeployServerResponding { return $true }
-                    Mock Test-OctopusVersionNewerThan { return $true } # just assume we're the most recent version
-                    Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
+                    BeforeAll {
+                        Mock Invoke-OctopusServerCommand #{write-host $args}
+                        Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstanceWithMetrics" }
+                        Mock Get-RegistryValue { return "478389" } # checking .net 4.5
+                        Mock Invoke-MsiExec {}
+                        Mock Get-LogDirectory {}
+                        Mock Request-File {}
+                        Mock Update-InstallState {}
+                        Mock Test-OctopusDeployServerResponding { return $true }
+                        Mock Test-OctopusVersionNewerThan { return $true } # just assume we're the most recent version
+                        Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
 
-                    $params = Get-RequestedConfiguration "NewInstanceWithMetrics"
-                    Set-TargetResource @params
-
+                        $params = Get-RequestedConfiguration "NewInstanceWithMetrics"
+                    }
                     Assert-ExpectedResult "NewInstanceWithMetrics"
                     it "Should download the MSI" {
+                        Set-TargetResource @params
                         Assert-MockCalled Request-File
+                    }
+                    it "Should install the MSI" {
+                        Set-TargetResource @params
                         Assert-MockCalled Invoke-MsiExec
                     }
                 }
 
                 Context "When MasterKey is supplied on new instance" {
-                    Mock Invoke-OctopusServerCommand #{write-host $args}
-                    Mock Get-TargetResource { return Get-CurrentConfiguration "MasterKeySupplied" }
-                    Mock Get-RegistryValue { return "478389" } # checking .net 4.5
-                    Mock Invoke-MsiExec {}
-                    Mock Get-LogDirectory {}
-                    Mock Request-File {}
-                    Mock Update-InstallState {}
-                    Mock Test-OctopusDeployServerResponding { return $true }
-                    Mock Test-OctopusVersionNewerThan { return $true } # just assume we're the most recent version
-                    Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
-
-                    $params = Get-RequestedConfiguration "MasterKeySupplied"
-
-                    Set-TargetResource @params
-
-                    it "Should download the MSI" {
-                        Assert-MockCalled Request-File
-                        Assert-MockCalled Invoke-MsiExec
+                    BeforeAll {
+                        Mock Invoke-OctopusServerCommand #{write-host $args}
+                        Mock Get-TargetResource { return Get-CurrentConfiguration "MasterKeySupplied" }
+                        Mock Get-RegistryValue { return "478389" } # checking .net 4.5
+                        Mock Invoke-MsiExec {}
+                        Mock Get-LogDirectory {}
+                        Mock Request-File {}
+                        Mock Update-InstallState {}
+                        Mock Test-OctopusDeployServerResponding { return $true }
+                        Mock Test-OctopusVersionNewerThan { return $true } # just assume we're the most recent version
+                        Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
+                        $params = Get-RequestedConfiguration "MasterKeySupplied"
                     }
                     Assert-ExpectedResult "MasterKeySupplied"
+                    it "Should download the MSI" {
+                        Set-TargetResource @params
+                        Assert-MockCalled Request-File
+                    }
+                    it "Should install the MSI" {
+                        Set-TargetResource @params
+                        Assert-MockCalled Invoke-MsiExec
+                    }
                 }
 
                 Context "When uninstalling running instance" {
-                    Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
-                    Mock Get-TargetResource { return Get-CurrentConfiguration "UninstallingRunningInstance" }
-                    Mock Invoke-MsiExec {}
-                    Mock Get-LogDirectory {}
-                    Mock Request-File {}
-                    Mock Get-ExistingOctopusService { return @() }
-                    Mock Get-LogDirectory { return Get-TempFolder }
-                    Mock Test-Path -ParameterFilter { $path -eq "$($env:SystemDrive)\Octopus\Octopus-x64.msi" } { return $true }
-                    Mock Start-Process { return @{ ExitCode = 0} }
-
-                    $params = Get-RequestedConfiguration "UninstallingRunningInstance"
-                    Set-TargetResource @params
-
+                    BeforeAll {
+                        Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
+                        Mock Get-TargetResource { return Get-CurrentConfiguration "UninstallingRunningInstance" }
+                        Mock Invoke-MsiExec {}
+                        Mock Get-LogDirectory {}
+                        Mock Request-File {}
+                        Mock Get-ExistingOctopusService { return @() }
+                        Mock Get-LogDirectory { return Get-TempFolder }
+                        Mock Test-Path -ParameterFilter { $path -eq "$($env:SystemDrive)\Octopus\Octopus-x64.msi" } { return $true }
+                        Mock Start-Process { return @{ ExitCode = 0} }
+                        $params = Get-RequestedConfiguration "UninstallingRunningInstance"
+                    }
+                    Assert-ExpectedResult "UninstallingRunningInstance"
                     it "Should not download the MSI" {
+                        Set-TargetResource @params
                         Assert-MockCalled Request-File -Times 0 -Exactly
+                    }
+                    it "Should not try and install the MSI" {
+                        Set-TargetResource @params
                         Assert-MockCalled Invoke-MsiExec -Times 0 -Exactly
                     }
                     it "Should uninstall the MSI" {
+                        Set-TargetResource @params
                         Assert-MockCalled Start-Process -Times 1 -Exactly -ParameterFilter { $FilePath -eq "msiexec.exe" -and $ArgumentList -eq "/x $($env:SystemDrive)\Octopus\Octopus-x64.msi /quiet /l*v $(Get-TempFolder)\Octopus-x64.msi.uninstall.log"}
                     }
-                    Assert-ExpectedResult "UninstallingRunningInstance"
                 }
 
                 Context "Run-on-server user - new install" {
-                    Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
-                    Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstallWithBuiltInWorker" }
-                    Mock Get-RegistryValue { return "478389" } # checking .net 4.5
-                    Mock Invoke-MsiExec {}
-                    Mock Get-LogDirectory {}
-                    Mock Request-File {}
-                    Mock Update-InstallState {}
-                    Mock Test-OctopusDeployServerResponding { return $true }
-                    Mock Test-OctopusVersionNewerThan { return $true }
-                    Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
+                    BeforeAll {
+                        Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
+                        Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstallWithBuiltInWorker" }
+                        Mock Get-RegistryValue { return "478389" } # checking .net 4.5
+                        Mock Invoke-MsiExec {}
+                        Mock Get-LogDirectory {}
+                        Mock Request-File {}
+                        Mock Update-InstallState {}
+                        Mock Test-OctopusDeployServerResponding { return $true }
+                        Mock Test-OctopusVersionNewerThan { return $true }
+                        Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
 
-                    $params = Get-RequestedConfiguration "NewInstallWithBuiltInWorker"
-                    Set-TargetResource @params
-
-                    it "Should download the MSI" {
-                        Assert-MockCalled Request-File
-                        Assert-MockCalled Invoke-MsiExec
+                        $params = Get-RequestedConfiguration "NewInstallWithBuiltInWorker"
                     }
                     Assert-ExpectedResult "NewInstallWithBuiltInWorker"
+                    it "Should download the MSI" {
+                        Set-TargetResource @params
+                        Assert-MockCalled Request-File
+                    }
+                    it "Should install the MSI" {
+                        Set-TargetResource @params
+                        Assert-MockCalled Invoke-MsiExec
+                    }
                 }
 
                 Context "Run-on-server user - existing install" {
-                    Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
-                    Mock Get-TargetResource { return Get-CurrentConfiguration "EnableBuiltInWorkerOnExistingInstance" }
-                    Mock Get-RegistryValue { return "478389" } # checking .net 4.5
-                    Mock Invoke-MsiExec {}
-                    Mock Get-LogDirectory {}
-                    Mock Request-File {}
-                    Mock Update-InstallState {}
-                    Mock Test-OctopusDeployServerResponding { return $true }
-                    Mock Test-OctopusVersionNewerThan { return $true }
-                    Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
+                    BeforeAll {
+                        Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
+                        Mock Get-TargetResource { return Get-CurrentConfiguration "EnableBuiltInWorkerOnExistingInstance" }
+                        Mock Get-RegistryValue { return "478389" } # checking .net 4.5
+                        Mock Invoke-MsiExec {}
+                        Mock Get-LogDirectory {}
+                        Mock Request-File {}
+                        Mock Update-InstallState {}
+                        Mock Test-OctopusDeployServerResponding { return $true }
+                        Mock Test-OctopusVersionNewerThan { return $true }
+                        Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
 
-                    $params = Get-RequestedConfiguration "EnableBuiltInWorkerOnExistingInstance"
-                    Set-TargetResource @params
-
-                    it "Should not download the MSI" {
-                        Assert-MockCalled Request-File -Times 0 -Exactly
-                        Assert-MockCalled Invoke-MsiExec -Times 0 -Exactly
+                        $params = Get-RequestedConfiguration "EnableBuiltInWorkerOnExistingInstance"
                     }
                     Assert-ExpectedResult "EnableBuiltInWorkerOnExistingInstance"
+                    it "Should not download the MSI" {
+                        Set-TargetResource @params
+                        Assert-MockCalled Request-File -Times 0 -Exactly
+                    }
+                    it "Should not try and install the MSI" {
+                        Set-TargetResource @params
+                        Assert-MockCalled Invoke-MsiExec -Times 0 -Exactly
+                    }
                 }
 
                 Context "Upgrade" {
-                    Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
-                    Mock Get-TargetResource { return Get-CurrentConfiguration "UpgradeExistingInstance" }
-                    Mock Get-RegistryValue { return "478389" } # checking .net 4.5
-                    Mock Invoke-MsiExec {}
-                    Mock Get-LogDirectory {}
-                    Mock Request-File {}
-                    Mock Update-InstallState {}
-                    Mock Test-OctopusDeployServerResponding { return $true }
-                    Mock Test-OctopusVersionNewerThan { return $true }
-                    Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
+                    BeforeAll {
+                        Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
+                        Mock Get-TargetResource { return Get-CurrentConfiguration "UpgradeExistingInstance" }
+                        Mock Get-RegistryValue { return "478389" } # checking .net 4.5
+                        Mock Invoke-MsiExec {}
+                        Mock Get-LogDirectory {}
+                        Mock Request-File {}
+                        Mock Update-InstallState {}
+                        Mock Test-OctopusDeployServerResponding { return $true }
+                        Mock Test-OctopusVersionNewerThan { return $true }
+                        Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
 
-                    $params = Get-RequestedConfiguration "UpgradeExistingInstance"
-                    Set-TargetResource @params
-
-                    it "Should download the MSI" {
-                        Assert-MockCalled Request-File
-                        Assert-MockCalled Invoke-MsiExec
+                        $params = Get-RequestedConfiguration "UpgradeExistingInstance"
                     }
                     Assert-ExpectedResult "UpgradeExistingInstance"
+                    it "Should download the MSI" {
+                        Set-TargetResource @params
+                        Assert-MockCalled Request-File
+                    }
+                    it "Should install the MSI" {
+                        Set-TargetResource @params
+                        Assert-MockCalled Invoke-MsiExec
+                    }
                 }
 
                 Context "Change WebListenPrefix" {
-                    Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
-                    Mock Get-TargetResource { return Get-CurrentConfiguration "ChangeWebListenPrefix" }
-                    Mock Get-RegistryValue { return "478389" } # checking .net 4.5
-                    Mock Invoke-MsiExec {}
-                    Mock Get-LogDirectory {}
-                    Mock Request-File {}
-                    Mock Update-InstallState {}
-                    Mock Test-OctopusDeployServerResponding { return $true }
-                    Mock Test-OctopusVersionNewerThan { return $true }
-                    Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
+                    BeforeAll {
+                        Mock Invoke-OctopusServerCommand #{ param ($arguments) write-host $arguments}
+                        Mock Get-TargetResource { return Get-CurrentConfiguration "ChangeWebListenPrefix" }
+                        Mock Get-RegistryValue { return "478389" } # checking .net 4.5
+                        Mock Invoke-MsiExec {}
+                        Mock Get-LogDirectory {}
+                        Mock Request-File {}
+                        Mock Update-InstallState {}
+                        Mock Test-OctopusDeployServerResponding { return $true }
+                        Mock Test-OctopusVersionNewerThan { return $true }
+                        Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
 
-                    $params = Get-RequestedConfiguration "ChangeWebListenPrefix"
-                    Set-TargetResource @params
-
-                    it "Should not download the MSI" {
-                        Assert-MockCalled Request-File -Times 0 -Exactly
-                        Assert-MockCalled Invoke-MsiExec -Times 0 -Exactly
+                        $params = Get-RequestedConfiguration "ChangeWebListenPrefix"
                     }
                     Assert-ExpectedResult "ChangeWebListenPrefix"
+                    it "Should not download the MSI" {
+                        Set-TargetResource @params
+                        Assert-MockCalled Request-File -Times 0 -Exactly
+                    }
+                    it "Should not try and install the MSI" {
+                        Set-TargetResource @params
+                        Assert-MockCalled Invoke-MsiExec -Times 0 -Exactly
+                    }
                 }
             }
         }

--- a/OctopusDSC/Tests/cOctopusServer.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServer.Tests.ps1
@@ -14,12 +14,6 @@ try
 
     InModuleScope $module.Name {
 
-        # Get-Service is not available on mac/unix systems - fake it
-        $getServiceCommand = Get-Command "Get-Service" -ErrorAction SilentlyContinue
-        if ($null -eq $getServiceCommand) {
-            function Get-Service {}
-        }
-
         Describe 'cOctopusServer' {
             BeforeAll {
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
@@ -29,22 +23,28 @@ try
                 }
                 Mock Import-ServerConfig { return $mockConfig }
 
-            function Get-DesiredConfiguration {
-                $pass = ConvertTo-SecureString "S3cur3P4ssphraseHere!" -AsPlainText -Force
-                $cred = New-Object System.Management.Automation.PSCredential ("Admin", $pass)
-
-                [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
-                $desiredConfiguration = @{
-                    Name                   = 'Stub'
-                    Ensure                 = 'Present'
-                    State                  = 'Started'
-                    WebListenPrefix        = "http://localhost:80"
-                    SqlDbConnectionString  = "conn-string"
-                    OctopusAdminCredential = $cred
+                # Get-Service is not available on mac/unix systems - fake it
+                $getServiceCommand = Get-Command "Get-Service" -ErrorAction SilentlyContinue
+                if ($null -eq $getServiceCommand) {
+                    function Get-Service {}
                 }
-                return $desiredConfiguration
+
+                function Get-DesiredConfiguration {
+                    $pass = ConvertTo-SecureString "S3cur3P4ssphraseHere!" -AsPlainText -Force
+                    $cred = New-Object System.Management.Automation.PSCredential ("Admin", $pass)
+
+                    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+                    $desiredConfiguration = @{
+                        Name                   = 'Stub'
+                        Ensure                 = 'Present'
+                        State                  = 'Started'
+                        WebListenPrefix        = "http://localhost:80"
+                        SqlDbConnectionString  = "conn-string"
+                        OctopusAdminCredential = $cred
+                    }
+                    return $desiredConfiguration
+                }
             }
-        }
 
             Context 'Get-TargetResource' {
                 Context 'When reg key exists and service exists and service started' {

--- a/OctopusDSC/Tests/cOctopusServer.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServer.Tests.ps1
@@ -4,7 +4,6 @@ param()
 
 $moduleName = Split-Path ($PSCommandPath -replace '\.Tests\.ps1$', '') -Leaf
 $modulePath = Resolve-Path "$PSCommandPath/../../DSCResources/$moduleName/$moduleName.psm1"
-$global:powershellHelpersPath = Resolve-Path "$PSCommandPath/../../../tests/powershell-helpers.ps1"
 $module = $null
 
 try
@@ -399,8 +398,6 @@ try
 
             Context "Octopus server command line" {
                 BeforeAll {
-                    . $global:dscHelpersPath
-
                     function Get-CurrentConfiguration ([string] $testName) {
                         & (Resolve-Path "$PSCommandPath/../../Tests/OctopusServerExeInvocationFiles/$testName/CurrentState.ps1")
                     }
@@ -418,8 +415,25 @@ try
                     }
                 }
 
+                function ConvertTo-Hashtable
+                {
+                    param (
+                        [Parameter(ValueFromPipeline = $true)]
+                        [Object[]] $InputObject
+                    )
+
+                    process {
+                        foreach ($object in $InputObject) {
+                            $hash = @{}
+                            foreach ($property in $object.PSObject.Properties) {
+                                $hash[$property.Name] = $property.Value
+                            }
+                            $hash
+                        }
+                    }
+                }
+
                 function Assert-ExpectedResult ([string] $testName) {
-                . $global:powershellHelpersPath
                     # todo: test order of execution here
                     $invocations = & (Resolve-Path "$PSCommandPath/../../Tests/OctopusServerExeInvocationFiles/$testName/ExpectedResult.ps1")
                     $name = @{label="line";expression={$_}};
@@ -477,7 +491,7 @@ try
                         Mock Test-OctopusDeployServerResponding { return $true }
                         Mock Test-OctopusVersionNewerThan { return $true } # just assume we're the most recent version
                         Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
-
+                        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
                         $params = Get-RequestedConfiguration "NewInstanceWithMetrics"
                     }
                     Assert-ExpectedResult "NewInstanceWithMetrics"
@@ -503,6 +517,7 @@ try
                         Mock Test-OctopusDeployServerResponding { return $true }
                         Mock Test-OctopusVersionNewerThan { return $true } # just assume we're the most recent version
                         Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
+                        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
                         $params = Get-RequestedConfiguration "MasterKeySupplied"
                     }
                     Assert-ExpectedResult "MasterKeySupplied"
@@ -527,6 +542,7 @@ try
                         Mock Get-LogDirectory { return Get-TempFolder }
                         Mock Test-Path -ParameterFilter { $path -eq "$($env:SystemDrive)\Octopus\Octopus-x64.msi" } { return $true }
                         Mock Start-Process { return @{ ExitCode = 0} }
+                        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
                         $params = Get-RequestedConfiguration "UninstallingRunningInstance"
                     }
                     Assert-ExpectedResult "UninstallingRunningInstance"
@@ -557,6 +573,7 @@ try
                         Mock Test-OctopusVersionNewerThan { return $true }
                         Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
 
+                        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
                         $params = Get-RequestedConfiguration "NewInstallWithBuiltInWorker"
                     }
                     Assert-ExpectedResult "NewInstallWithBuiltInWorker"
@@ -583,6 +600,7 @@ try
                         Mock Test-OctopusVersionNewerThan { return $true }
                         Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
 
+                        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
                         $params = Get-RequestedConfiguration "EnableBuiltInWorkerOnExistingInstance"
                     }
                     Assert-ExpectedResult "EnableBuiltInWorkerOnExistingInstance"
@@ -609,6 +627,7 @@ try
                         Mock Test-OctopusVersionNewerThan { return $true }
                         Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
 
+                        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
                         $params = Get-RequestedConfiguration "UpgradeExistingInstance"
                     }
                     Assert-ExpectedResult "UpgradeExistingInstance"
@@ -635,6 +654,7 @@ try
                         Mock Test-OctopusVersionNewerThan { return $true }
                         Mock ConvertFrom-SecureString { return "" } # mock this, as its not available on mac/linux
 
+                        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
                         $params = Get-RequestedConfiguration "ChangeWebListenPrefix"
                     }
                     Assert-ExpectedResult "ChangeWebListenPrefix"

--- a/OctopusDSC/Tests/cOctopusServerAzureADAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerAzureADAuthentication.Tests.ps1
@@ -3,6 +3,7 @@
 $moduleName = Split-Path ($PSCommandPath -replace '\.Tests\.ps1$', '') -Leaf
 $modulePath = Split-Path $PSCommandPath -Parent
 $modulePath = Resolve-Path "$PSCommandPath/../../DSCResources/$moduleName/$moduleName.psm1"
+$script:dscHelpersPath = Resolve-Path "$PSCommandPath/../../OctopusDSCHelpers.ps1"
 $module = $null
 
 try
@@ -40,35 +41,37 @@ try
                     }
 
                     $config = Get-TargetResource @desiredConfiguration
-                    $config.InstanceName    | Should Be 'OctopusServer'
-                    $config.Enabled         | Should Be $true
-                    $config.Issuer          | Should Be "https://login.microsoftonline.com/b91ebf6a-84be-4c6f-97f3-32a1d0a11c8a"
-                    $config.ClientID        | Should Be "0272262a-b31d-4acf-8891-56e96d302018"
+                    $config.InstanceName    | Should -Be 'OctopusServer'
+                    $config.Enabled         | Should -Be $true
+                    $config.Issuer          | Should -Be "https://login.microsoftonline.com/b91ebf6a-84be-4c6f-97f3-32a1d0a11c8a"
+                    $config.ClientID        | Should -Be "0272262a-b31d-4acf-8891-56e96d302018"
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
                     Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should Throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
-                    { Get-TargetResource @desiredConfiguration } | Should Throw "This resource only supports Octopus Deploy 3.5.0+."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."
                 }
             }
 
             Context 'Test-TargetResource' {
-                $response = @{ InstanceName="OctopusServer"; Enabled=$true }
-                Mock Get-TargetResource { return $response }
+                BeforeAll {
+                    $response = @{ InstanceName="OctopusServer"; Enabled=$true }
+                    Mock Get-TargetResource { return $response }
+                }
 
                 It 'Returns True when values the same' {
                     $response['Enabled'] = $true
                     $response['Issuer'] = "https://login.microsoftonline.com/b91ebf6a-84be-4c6f-97f3-32a1d0a11c8a"
                     $response['ClientID'] = "0272262a-b31d-4acf-8891-56e96d302018"
 
-                    Test-TargetResource @desiredConfiguration | Should Be $true
+                    Test-TargetResource @desiredConfiguration | Should -Be $true
                 }
 
                 It 'Returns false when its currently disabled' {
@@ -76,7 +79,7 @@ try
                     $response['Issuer'] = "https://login.microsoftonline.com/b91ebf6a-84be-4c6f-97f3-32a1d0a11c8a"
                     $response['ClientID'] = "0272262a-b31d-4acf-8891-56e96d302018"
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false when issuer is currently different' {
@@ -84,14 +87,14 @@ try
                     $response['Issuer'] = "https://login.microsoftonline.com/32a1d0a11c8a-b91ebf6a-84be-4c6f-97f3"
                     $response['ClientID'] = "0272262a-b31d-4acf-8891-56e96d302018"
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false when the clientid is currently different' {
                     $response['Enabled'] = $true
                     $response['Issuer'] = "https://login.microsoftonline.com/b91ebf6a-84be-4c6f-97f3-32a1d0a11c8a"
                     $response['ClientID'] = "56e96d302018-0272262a-b31d-4acf-8891"
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Calls Get-TargetResource (and therefore inherits its checks)' {
@@ -101,6 +104,9 @@ try
             }
 
             Context 'Set-TargetResource' {
+                BeforeAll {
+                    . $dscHelpersPath
+                }
                 It 'Calls Invoke-OctopusServerCommand with the correct arguments' {
                     Mock Invoke-OctopusServerCommand
 
@@ -108,7 +114,7 @@ try
                                        -Enabled $true `
                                        -Issuer "https://login.microsoftonline.com/b91ebf6a-84be-4c6f-97f3-32a1d0a11c8a" `
                                        -ClientID "0272262a-b31d-4acf-8891-56e96d302018"
-                    Assert-MockCalled Invoke-OctopusServerCommand -ParameterFilter { ($arguments -join ' ') -eq 'configure --console --instance SuperOctopus --azureADIsEnabled true --azureADIssuer https://login.microsoftonline.com/b91ebf6a-84be-4c6f-97f3-32a1d0a11c8a --azureADClientId 0272262a-b31d-4acf-8891-56e96d302018'}
+                    Assert-MockCalled Invoke-OctopusServerCommand -ParameterFilter { ($cmdArgs -join ' ') -eq 'configure --console --instance SuperOctopus --azureADIsEnabled true --azureADIssuer https://login.microsoftonline.com/b91ebf6a-84be-4c6f-97f3-32a1d0a11c8a --azureADClientId 0272262a-b31d-4acf-8891-56e96d302018'}
                 }
             }
         }

--- a/OctopusDSC/Tests/cOctopusServerGoogleAppsAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerGoogleAppsAuthentication.Tests.ps1
@@ -3,6 +3,7 @@
 $moduleName = Split-Path ($PSCommandPath -replace '\.Tests\.ps1$', '') -Leaf
 $modulePath = Split-Path $PSCommandPath -Parent
 $modulePath = Resolve-Path "$PSCommandPath/../../DSCResources/$moduleName/$moduleName.psm1"
+$script:dscHelpersPath = Resolve-Path "$PSCommandPath/../../OctopusDSCHelpers.ps1"
 $module = $null
 
 try
@@ -40,35 +41,37 @@ try
                     }
 
                     $config = Get-TargetResource @desiredConfiguration
-                    $config.InstanceName   | Should Be 'OctopusServer'
-                    $config.Enabled        | Should Be $true
-                    $config.ClientID       | Should Be "5743519123-1232358520259-3634528"
-                    $config.HostedDomain   | Should Be "https://octopus.example.com"
+                    $config.InstanceName   | Should -Be 'OctopusServer'
+                    $config.Enabled        | Should -Be $true
+                    $config.ClientID       | Should -Be "5743519123-1232358520259-3634528"
+                    $config.HostedDomain   | Should -Be "https://octopus.example.com"
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
                     Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should Throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
-                    { Get-TargetResource @desiredConfiguration } | Should Throw "This resource only supports Octopus Deploy 3.5.0+."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."
                 }
             }
 
             Context 'Test-TargetResource' {
-                $response = @{ InstanceName="OctopusServer"; Enabled=$true }
-                Mock Get-TargetResource { return $response }
+                BeforeAll {
+                    $response = @{ InstanceName="OctopusServer"; Enabled=$true }
+                    Mock Get-TargetResource { return $response }
+                }
 
                 It 'Returns True when values the same' {
                     $response['Enabled'] = $true
                     $response['ClientID'] = "5743519123-1232358520259-3634528"
                     $response['HostedDomain'] = "https://octopus.example.com"
 
-                    Test-TargetResource @desiredConfiguration | Should Be $true
+                    Test-TargetResource @desiredConfiguration | Should -Be $true
                 }
 
                 It 'Returns false when its currently disabled' {
@@ -76,7 +79,7 @@ try
                     $response['ClientID'] = "5743519123-1232358520259-3634528"
                     $response['HostedDomain'] = "https://octopus.example.com"
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false when ClientID is currently different' {
@@ -84,14 +87,14 @@ try
                     $response['ClientID'] = "111111111-2222222222222-3333333"
                     $response['HostedDomain'] = "https://octopus.example.com"
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false when the container is currently different' {
                     $response['Enabled'] = $false
                     $response['ClientID'] = "5743519123-1232358520259-3634528"
                     $response['HostedDomain'] = "https://octopusdeploy.example.com"
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Calls Get-TargetResource (and therefore inherits its checks)' {
@@ -101,6 +104,9 @@ try
             }
 
             Context 'Set-TargetResource' {
+                BeforeAll {
+                    . $dscHelpersPath
+                }
                 It 'Calls Invoke-OctopusServerCommand with the correct arguments' {
                     Mock Invoke-OctopusServerCommand
 
@@ -108,7 +114,7 @@ try
                                        -Enabled $false `
                                        -ClientID "5743519123-1232358520259-3634528" `
                                        -HostedDomain "https://octopus.example.com"
-                    Assert-MockCalled Invoke-OctopusServerCommand -ParameterFilter { ($arguments -join ' ') -eq 'configure --console --instance SuperOctopus --googleAppsIsEnabled false --googleAppsClientID 5743519123-1232358520259-3634528 --googleAppsHostedDomain https://octopus.example.com'}
+                    Assert-MockCalled Invoke-OctopusServerCommand -ParameterFilter { ($cmdArgs -join ' ') -eq 'configure --console --instance SuperOctopus --googleAppsIsEnabled false --googleAppsClientID 5743519123-1232358520259-3634528 --googleAppsHostedDomain https://octopus.example.com'}
                 }
             }
         }

--- a/OctopusDSC/Tests/cOctopusServerGuestAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerGuestAuthentication.Tests.ps1
@@ -3,6 +3,7 @@
 $moduleName = Split-Path ($PSCommandPath -replace '\.Tests\.ps1$', '') -Leaf
 $modulePath = Split-Path $PSCommandPath -Parent
 $modulePath = Resolve-Path "$PSCommandPath/../../DSCResources/$moduleName/$moduleName.psm1"
+$script:dscHelpersPath = Resolve-Path "$PSCommandPath/../../OctopusDSCHelpers.ps1"
 $module = $null
 
 try
@@ -28,26 +29,28 @@ try
                     Mock Get-ServerConfiguration { return  @{Octopus = @{ WebPortal = @{ GuestLoginEnabled = $true }}} }
 
                     $config = Get-TargetResource @desiredConfiguration
-                    $config.InstanceName            | Should Be 'OctopusServer'
-                    $config.Enabled                 | Should Be $true
+                    $config.InstanceName            | Should -Be 'OctopusServer'
+                    $config.Enabled                 | Should -Be $true
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
                     Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should Throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
-                    { Get-TargetResource @desiredConfiguration } | Should Throw "This resource only supports Octopus Deploy 3.5.0+."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."
                 }
             }
 
             Context 'Test-TargetResource' {
-                $response = @{ InstanceName="OctopusServer"; Enabled=$true }
-                Mock Get-TargetResource { return $response }
+                BeforeAll {
+                    $response = @{ InstanceName="OctopusServer"; Enabled=$true }
+                    Mock Get-TargetResource { return $response }
+                }
 
                 It 'Returns True when its currently enabled' {
                     $desiredConfiguration['InstanceName'] = 'OctopusServer'
@@ -55,7 +58,7 @@ try
                     $response['InstanceName'] = 'OctopusServer'
                     $response['Enabled'] = $true
 
-                    Test-TargetResource @desiredConfiguration | Should Be $true
+                    Test-TargetResource @desiredConfiguration | Should -Be $true
                 }
 
                It 'Returns false when its currently disabled' {
@@ -64,7 +67,7 @@ try
                     $response['InstanceName'] = 'OctopusServer'
                     $response['Enabled'] = $false
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Calls Get-TargetResource (and therefore inherits its checks)' {
@@ -74,11 +77,14 @@ try
             }
 
             Context 'Set-TargetResource' {
+                BeforeAll {
+                    . $dscHelpersPath
+                }
                 It 'Calls Invoke-OctopusServerCommand with the correct arguments' {
                     Mock Invoke-OctopusServerCommand
 
                     Set-TargetResource -InstanceName 'SuperOctopus' -Enabled $false
-                    Assert-MockCalled Invoke-OctopusServerCommand -ParameterFilter { ($arguments -join ' ') -eq 'configure --console --instance SuperOctopus --guestLoginEnabled false'}
+                    Assert-MockCalled Invoke-OctopusServerCommand -ParameterFilter { ($cmdArgs -join ' ') -eq 'configure --console --instance SuperOctopus --guestLoginEnabled false'}
                 }
             }
         }

--- a/OctopusDSC/Tests/cOctopusServerOktaAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerOktaAuthentication.Tests.ps1
@@ -3,6 +3,7 @@
 $moduleName = Split-Path ($PSCommandPath -replace '\.Tests\.ps1$', '') -Leaf
 $modulePath = Split-Path $PSCommandPath -Parent
 $modulePath = Resolve-Path "$PSCommandPath/../../DSCResources/$moduleName/$moduleName.psm1"
+$script:dscHelpersPath = Resolve-Path "$PSCommandPath/../../OctopusDSCHelpers.ps1"
 $module = $null
 
 try
@@ -40,35 +41,37 @@ try
                     }
 
                     $config = Get-TargetResource @desiredConfiguration
-                    $config.InstanceName    | Should Be 'OctopusServer'
-                    $config.Enabled         | Should Be $true
-                    $config.Issuer          | Should Be "https://dev-258250.oktapreview.com"
-                    $config.ClientID        | Should Be "752nx5basdskrsbqansE"
+                    $config.InstanceName    | Should -Be 'OctopusServer'
+                    $config.Enabled         | Should -Be $true
+                    $config.Issuer          | Should -Be "https://dev-258250.oktapreview.com"
+                    $config.ClientID        | Should -Be "752nx5basdskrsbqansE"
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
                     Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsOktaAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should Throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsOktaAuthenticationProvider { return $false }
-                    { Get-TargetResource @desiredConfiguration } | Should Throw "This resource only supports Octopus Deploy 3.16.0+."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.16.0+."
                 }
             }
 
             Context 'Test-TargetResource' {
-                $response = @{ InstanceName="OctopusServer"; Enabled=$true }
-                Mock Get-TargetResource { return $response }
+                BeforeAll {
+                    $response = @{ InstanceName="OctopusServer"; Enabled=$true }
+                    Mock Get-TargetResource { return $response }
+                }
 
                 It 'Returns True when values the same' {
                     $response['Enabled'] = $true
                     $response['Issuer'] = "https://dev-258250.oktapreview.com"
                     $response['ClientID'] = "752nx5basdskrsbqansE"
 
-                    Test-TargetResource @desiredConfiguration | Should Be $true
+                    Test-TargetResource @desiredConfiguration | Should -Be $true
                 }
 
                 It 'Returns false when its currently disabled' {
@@ -76,7 +79,7 @@ try
                     $response['Issuer'] = "https://dev-258250.oktapreview.com"
                     $response['ClientID'] = "752nx5basdskrsbqansE"
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false when issuer is currently different' {
@@ -84,14 +87,14 @@ try
                     $response['Issuer'] = "https://dev-258251.oktapreview.com"
                     $response['ClientID'] = "752nx5basdskrsbqansE"
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false when the clientid is currently different' {
                     $response['Enabled'] = $true
                     $response['Issuer'] = "https://dev-258250.oktapreview.com"
                     $response['ClientID'] = "73sfca4fvbsfnw42huDs"
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Calls Get-TargetResource (and therefore inherits its checks)' {
@@ -101,6 +104,9 @@ try
             }
 
             Context 'Set-TargetResource' {
+                BeforeAll {
+                    . $dscHelpersPath
+                }
                 It 'Calls Invoke-OctopusServerCommand with the correct arguments' {
                     Mock Invoke-OctopusServerCommand
 
@@ -108,7 +114,7 @@ try
                                        -Enabled $true `
                                        -Issuer "https://dev-258250.oktapreview.com" `
                                        -ClientID "752nx5basdskrsbqansE"
-                    Assert-MockCalled Invoke-OctopusServerCommand -ParameterFilter { ($arguments -join ' ') -eq 'configure --console --instance SuperOctopus --oktaIsEnabled true --oktaIssuer https://dev-258250.oktapreview.com --oktaClientId 752nx5basdskrsbqansE'}
+                    Assert-MockCalled Invoke-OctopusServerCommand -ParameterFilter { ($cmdArgs -join ' ') -eq 'configure --console --instance SuperOctopus --oktaIsEnabled true --oktaIssuer https://dev-258250.oktapreview.com --oktaClientId 752nx5basdskrsbqansE'}
                 }
             }
         }

--- a/OctopusDSC/Tests/cOctopusServerSpace.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerSpace.Tests.ps1
@@ -44,7 +44,7 @@ try
                                                  -SpaceManagersTeamMembers @('admin') `
                                                  -SpaceManagersTeams @('Everyone') `
                                                  -OctopusCredentials $creds `
-                                                 -OctopusApiKey $creds } | should throw "Please provide either 'OctopusCredentials' or 'OctopusApiKey', not both."
+                                                 -OctopusApiKey $creds } | Should -throw "Please provide either 'OctopusCredentials' or 'OctopusApiKey', not both."
                 }
 
                 It 'Throws when neither OctopusCredentials and OctopusApiKey are provided' {
@@ -53,7 +53,7 @@ try
                                                  -Name 'Integration Team' `
                                                  -Description 'Integration team space' `
                                                  -SpaceManagersTeamMembers @('admin') `
-                                                 -SpaceManagersTeams @('Everyone') } | should throw "Please provide either 'OctopusCredentials' or 'OctopusApiKey'."
+                                                 -SpaceManagersTeams @('Everyone') } | Should -throw "Please provide either 'OctopusCredentials' or 'OctopusApiKey'."
                 }
 
                 #todo: throw if neither SpaceManagersTeams or SpaceManagersTeamMembers not provided
@@ -62,7 +62,7 @@ try
                                                  -Ensure 'Present' `
                                                  -Name 'Integration Team' `
                                                  -Description 'Integration team space' `
-                                                 -OctopusApiKey $creds } | should throw "Please provide at least one of 'SpaceManagersTeamMembers' or 'SpaceManagersTeams'."
+                                                 -OctopusApiKey $creds } | Should -throw "Please provide at least one of 'SpaceManagersTeamMembers' or 'SpaceManagersTeams'."
                 }
             }
 
@@ -77,7 +77,7 @@ try
                                                  -SpaceManagersTeamMembers @('admin') `
                                                  -SpaceManagersTeams @('Everyone') `
                                                  -OctopusCredentials $creds
-                    $result.Ensure | should be 'Present'
+                    $result.Ensure | Should -Be 'Present'
                 }
             }
 
@@ -91,13 +91,15 @@ try
                                                  -SpaceManagersTeamMembers @('admin') `
                                                  -SpaceManagersTeams @('Everyone') `
                                                  -OctopusCredentials $creds
-                    $result.Ensure | should be 'Absent'
+                    $result.Ensure | Should -Be 'Absent'
                 }
             }
 
             Context 'Test-TargetResource' {
-                $response = @{  }
-                Mock Get-TargetResource { return $response }
+                BeforeAll {
+                    $response = @{  }
+                    Mock Get-TargetResource { return $response }
+                }
 
                 It 'Returns false if space does not exist' {
                     $password = ConvertTo-SecureString "1a2b3c4d5e6f" -AsPlainText -Force
@@ -120,7 +122,7 @@ try
                     $response['SpaceManagersTeams'] = $null
                     $response['OctopusCredentials'] = $creds
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns true if space does exist and all properties match' {
@@ -143,7 +145,7 @@ try
                     $response['SpaceManagersTeams'] = @('Everyone')
                     $response['OctopusCredentials'] = $creds
 
-                    Test-TargetResource @desiredConfiguration | Should Be $true
+                    Test-TargetResource @desiredConfiguration | Should -Be $true
                 }
 
                 It 'Returns false if description is different' {
@@ -166,7 +168,7 @@ try
                     $response['SpaceManagersTeams'] = @('Everyone')
                     $response['OctopusCredentials'] = $creds
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false if SpaceManagersTeamMembers is different' {
@@ -189,7 +191,7 @@ try
                     $response['SpaceManagersTeams'] = @('Everyone')
                     $response['OctopusCredentials'] = $creds
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false if SpaceManagersTeams is different' {
@@ -212,7 +214,7 @@ try
                     $response['SpaceManagersTeams'] = @('TeamX')
                     $response['OctopusCredentials'] = $creds
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Calls Get-TargetResource (and therefore inherits its checks)' {
@@ -315,86 +317,98 @@ try
             }
 
             Context 'Team and User mapping' {
-                $spacesRepository = New-Object -TypeName PSObject
-                $getSpaceResponse = @{
-                    Id = "Spaces-262";
-                    Name = "Integration Space";
-                    Description = "The old description";
-                    IsDefault = $false;
-                    TaskQueueStopped = $false;
-                    SpaceManagersTeams = @("teams-spacemanagers-Spaces-262", "teams-everyone");
-                    SpaceManagersTeamMembers = @("Users-582") }
-                $spacesRepository | Add-Member -MemberType ScriptMethod -Name "FindByName" -Force -Value { return $getSpaceResponse }
-                $script:valueReceivedByModifyFunction = $null
-                $spacesRepository | Add-Member -MemberType ScriptMethod -Name "Modify" -Force -Value { param($space) $script:valueReceivedByModifyFunction = $space }
-                $script:valueReceivedByCreateFunction = $null
-                $spacesRepository | Add-Member -MemberType ScriptMethod -Name "Create" -Force -Value { param($space) $script:valueReceivedByCreateFunction = $space }
+                BeforeAll {
+                    $spacesRepository = New-Object -TypeName PSObject
+                    $getSpaceResponse = @{
+                        Id = "Spaces-262";
+                        Name = "Integration Space";
+                        Description = "The old description";
+                        IsDefault = $false;
+                        TaskQueueStopped = $false;
+                        SpaceManagersTeams = @("teams-spacemanagers-Spaces-262", "teams-everyone");
+                        SpaceManagersTeamMembers = @("Users-582") }
+                    $spacesRepository | Add-Member -MemberType ScriptMethod -Name "FindByName" -Force -Value { return $getSpaceResponse }
+                    $script:valueReceivedByModifyFunction = $null
+                    $spacesRepository | Add-Member -MemberType ScriptMethod -Name "Modify" -Force -Value { param($space) $script:valueReceivedByModifyFunction = $space }
+                    $script:valueReceivedByCreateFunction = $null
+                    $spacesRepository | Add-Member -MemberType ScriptMethod -Name "Create" -Force -Value { param($space) $script:valueReceivedByCreateFunction = $space }
 
-                $usersRepository = New-Object -TypeName PSObject
-                $findUsersResponse = @(@{ Id = "Users-1001"; Username = "bob@example.com"}, @{ Id = "Users-582"; Username = 'admin'} )
-                $usersRepository | Add-Member -MemberType ScriptMethod -Name "FindAll" -Force -Value { return $findUsersResponse }
+                    $usersRepository = New-Object -TypeName PSObject
+                    $findUsersResponse = @(@{ Id = "Users-1001"; Username = "bob@example.com"}, @{ Id = "Users-582"; Username = 'admin'} )
+                    $usersRepository | Add-Member -MemberType ScriptMethod -Name "FindAll" -Force -Value { return $findUsersResponse }
 
-                $teamsRepository = New-Object -TypeName PSObject
-                $findTeamsResponse = @(
-                    @{ Id = "teams-everyone"; Name = "Everyone"; SpaceId = $null },
-                    @{ Id = "teams-spacemanagers-Spaces-271"; Name = 'Space Managers'; SpaceId = 'Spaces-271'},  # team in a diff space
-                    @{ Id = "teams-spacemanagers-Spaces-262"; Name = 'Space Managers'; SpaceId = 'Spaces-262'} )
-                $teamsRepository | Add-Member -MemberType ScriptMethod -Name "FindAll" -Force -Value { return $findTeamsResponse }
+                    $teamsRepository = New-Object -TypeName PSObject
+                    $findTeamsResponse = @(
+                        @{ Id = "teams-everyone"; Name = "Everyone"; SpaceId = $null },
+                        @{ Id = "teams-spacemanagers-Spaces-271"; Name = 'Space Managers'; SpaceId = 'Spaces-271'},  # team in a diff space
+                        @{ Id = "teams-spacemanagers-Spaces-262"; Name = 'Space Managers'; SpaceId = 'Spaces-262'} )
+                    $teamsRepository | Add-Member -MemberType ScriptMethod -Name "FindAll" -Force -Value { return $findTeamsResponse }
 
-                $mockRepository = New-Object -TypeName PSObject -Property @{
-                    Spaces = $spacesRepository
-                    Teams = $teamsRepository
-                    Users = $usersRepository
+                    $mockRepository = New-Object -TypeName PSObject -Property @{
+                        Spaces = $spacesRepository
+                        Teams = $teamsRepository
+                        Users = $usersRepository
+                    }
+                    Mock Get-OctopusClientRepository { return $mockRepository }
                 }
-                Mock Get-OctopusClientRepository { return $mockRepository }
 
                 Context 'Get-Space' {
-                    $space = Get-Space `
-                        -Url 'https://octopus.example.com' `
-                        -Name 'Integration Team' `
-                        -OctopusCredentials $null `
-                        -OctopusApiKey $null
+
                     It 'Maps user ids returned by api to names' {
-                        $space.SpaceManagersTeamMembers | should be @('admin')
+                        $space = Get-Space `
+                            -Url 'https://octopus.example.com' `
+                            -Name 'Integration Team' `
+                            -OctopusCredentials $null `
+                            -OctopusApiKey $null
+                        $space.SpaceManagersTeamMembers | Should -Be @('admin')
                     }
                     It 'Maps team ids returned by api to names' {
-                        $space.SpaceManagersTeams | should be @('Space Managers', 'Everyone')
+                        $space = Get-Space `
+                            -Url 'https://octopus.example.com' `
+                            -Name 'Integration Team' `
+                            -OctopusCredentials $null `
+                            -OctopusApiKey $null
+                        $space.SpaceManagersTeams | Should -Be @('Space Managers', 'Everyone')
                     }
                 }
 
                 Context 'Update-Space' {
-                    Update-Space `
-                        -Url 'https://octopus.example.com' `
-                        -Name 'Integration Team' `
-                        -Description 'The new description' `
-                        -SpaceManagersTeamMembers @('admin') `
-                        -SpaceManagersTeams @('Everyone') `
-                        -OctopusCredentials $null `
-                        -OctopusApiKey $null
+                    BeforeAll {
+                        Update-Space `
+                            -Url 'https://octopus.example.com' `
+                            -Name 'Integration Team' `
+                            -Description 'The new description' `
+                            -SpaceManagersTeamMembers @('admin') `
+                            -SpaceManagersTeams @('Everyone') `
+                            -OctopusCredentials $null `
+                            -OctopusApiKey $null
+                    }
                     It 'Maps user names supplied by user to ids' {
-                        $script:valueReceivedByModifyFunction.SpaceManagersTeamMembers | should be @("Users-582")
+                        $script:valueReceivedByModifyFunction.SpaceManagersTeamMembers | Should -Be @("Users-582")
                     }
                     It 'Maps team names supplied by user to ids and adds space managers' {
-                        $script:valueReceivedByModifyFunction.SpaceManagersTeams | should be @("teams-everyone", "teams-spacemanagers-Spaces-262")
+                        $script:valueReceivedByModifyFunction.SpaceManagersTeams | Should -Be @("teams-everyone", "teams-spacemanagers-Spaces-262")
                     }
                 }
 
                 Context 'New-Space' {
-                    Mock New-SpaceResource { return @{} }
-                    Mock ConvertTo-ReferenceCollection { param($list) return $list }
-                    New-Space `
-                        -Url 'https://octopus.example.com' `
-                        -Name 'Integration Team' `
-                        -Description 'The new description' `
-                        -SpaceManagersTeamMembers @('admin') `
-                        -SpaceManagersTeams @('Everyone') `
-                        -OctopusCredentials $null `
-                        -OctopusApiKey $null
+                    BeforeAll {
+                        Mock New-SpaceResource { return @{} }
+                        Mock ConvertTo-ReferenceCollection { param($list) return $list }
+                        New-Space `
+                            -Url 'https://octopus.example.com' `
+                            -Name 'Integration Team' `
+                            -Description 'The new description' `
+                            -SpaceManagersTeamMembers @('admin') `
+                            -SpaceManagersTeams @('Everyone') `
+                            -OctopusCredentials $null `
+                            -OctopusApiKey $null
+                    }
                     It 'Maps user names supplied by user to ids' {
-                        $script:valueReceivedByCreateFunction.SpaceManagersTeamMembers | should be @("Users-582")
+                        $script:valueReceivedByCreateFunction.SpaceManagersTeamMembers | Should -Be @("Users-582")
                     }
                     It 'Maps team names supplied by user to ids and adds space managers' {
-                        $script:valueReceivedByCreateFunction.SpaceManagersTeams | should be @("teams-everyone")
+                        $script:valueReceivedByCreateFunction.SpaceManagersTeams | Should -Be @("teams-everyone")
                     }
                 }
             }

--- a/OctopusDSC/Tests/cOctopusServerWatchdog.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerWatchdog.Tests.ps1
@@ -3,7 +3,6 @@
 $moduleName = Split-Path ($PSCommandPath -replace '\.Tests\.ps1$', '') -Leaf
 $modulePath = Split-Path $PSCommandPath -Parent
 $modulePath = Resolve-Path "$PSCommandPath/../../DSCResources/$moduleName/$moduleName.psm1"
-$script:dscHelpersPath = Resolve-Path "$PSCommandPath/../../OctopusDSCHelpers.ps1"
 $module = $null
 
 try
@@ -104,9 +103,6 @@ try
             }
 
             Context 'Set-TargetResource' {
-                BeforeAll {
-                    . $dscHelpersPath
-                }
                 It 'Calls Invoke-OctopusServerCommand with the correct arguments to enable' {
                     Mock Invoke-OctopusServerCommand
 

--- a/OctopusDSC/Tests/cOctopusServerWatchdog.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerWatchdog.Tests.ps1
@@ -3,6 +3,7 @@
 $moduleName = Split-Path ($PSCommandPath -replace '\.Tests\.ps1$', '') -Leaf
 $modulePath = Split-Path $PSCommandPath -Parent
 $modulePath = Resolve-Path "$PSCommandPath/../../DSCResources/$moduleName/$moduleName.psm1"
+$script:dscHelpersPath = Resolve-Path "$PSCommandPath/../../OctopusDSCHelpers.ps1"
 $module = $null
 
 try
@@ -40,35 +41,37 @@ try
                     }
 
                     $config = Get-TargetResource @desiredConfiguration
-                    $config.InstanceName    | Should Be 'OctopusServer'
-                    $config.Enabled         | Should Be $true
-                    $config.Interval        | Should Be 5
-                    $config.Instances       | Should Be "master"
+                    $config.InstanceName    | Should -Be 'OctopusServer'
+                    $config.Enabled         | Should -Be $true
+                    $config.Interval        | Should -Be 5
+                    $config.Instances       | Should -Be "master"
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
                     Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsWatchdogInShowConfiguration { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should Throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsWatchdogInShowConfiguration { return $false }
-                    { Get-TargetResource @desiredConfiguration } | Should Throw "This resource only supports Octopus Deploy 3.17.0+."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.17.0+."
                 }
             }
 
             Context 'Test-TargetResource' {
-                $response = @{ InstanceName="OctopusServer"; Enabled=$true }
-                Mock Get-TargetResource { return $response }
+                BeforeAll {
+                    $response = @{ InstanceName="OctopusServer"; Enabled=$true }
+                    Mock Get-TargetResource { return $response }
+                }
 
                 It 'Returns True when values the same' {
                     $response['Enabled'] = $true
                     $response['Interval'] = 5
                     $response['Instances'] = "*"
 
-                    Test-TargetResource @desiredConfiguration | Should Be $true
+                    Test-TargetResource @desiredConfiguration | Should -Be $true
                 }
 
                 It 'Returns false when its currently disabled' {
@@ -76,7 +79,7 @@ try
                     $response['Interval'] = 5
                     $response['Instances'] = "*"
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false when interval is currently different' {
@@ -84,14 +87,14 @@ try
                     $response['Interval'] = 10
                     $response['Instances'] = "*"
 
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Returns false when the Instances is currently different' {
                     $response['Enabled'] = $true
                     $response['Interval'] = 5
                     $response['Instances'] = "master"
-                    Test-TargetResource @desiredConfiguration | Should Be $false
+                    Test-TargetResource @desiredConfiguration | Should -Be $false
                 }
 
                 It 'Calls Get-TargetResource (and therefore inherits its checks)' {
@@ -101,6 +104,9 @@ try
             }
 
             Context 'Set-TargetResource' {
+                BeforeAll {
+                    . $dscHelpersPath
+                }
                 It 'Calls Invoke-OctopusServerCommand with the correct arguments to enable' {
                     Mock Invoke-OctopusServerCommand
 
@@ -108,7 +114,7 @@ try
                                        -Enabled $true `
                                        -Interval 5 `
                                        -Instances "*"
-                    Assert-MockCalled Invoke-OctopusServerCommand -ParameterFilter { ($arguments -join ' ') -eq 'watchdog --create --interval 5 --instances "*"'}
+                    Assert-MockCalled Invoke-OctopusServerCommand -ParameterFilter { ($cmdArgs -join ' ') -eq 'watchdog --create --interval 5 --instances "*"'}
                 }
 
                 It 'Calls Invoke-OctopusServerCommand with the correct arguments to disable' {
@@ -118,7 +124,7 @@ try
                                        -Enabled $false `
                                        -Interval 5 `
                                        -Instances "*"
-                    Assert-MockCalled Invoke-OctopusServerCommand -ParameterFilter { ($arguments -join ' ') -eq 'watchdog --delete'}
+                    Assert-MockCalled Invoke-OctopusServerCommand -ParameterFilter { ($cmdArgs -join ' ') -eq 'watchdog --delete'}
                 }
             }
         }

--- a/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
@@ -16,7 +16,10 @@ try
             # Get-Service is not available on mac/unix systems - fake it
             $getServiceCommand = Get-Command "Get-Service" -ErrorAction SilentlyContinue
             if ($null -eq $getServiceCommand) {
-                function Get-Service {}
+                function Get-Service {
+                    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidOverwritingBuiltInCmdlets', '', Justification='Get-Service is not available on mac/unix systems, so without faking it, our builds fail')]
+                    param()
+                }
             }
         }
 
@@ -330,9 +333,19 @@ try
                 # create stubs for these cmdlets on linux/mac as they dont natively exist
                 # leading to pester complaining that it cant mock it...
                 if (-not $isWindows) {
-                    function Start-Service {}
-                    function Stop-Service {}
-                    function Get-CimInstance {}
+                    function Start-Service {
+                        [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidOverwritingBuiltInCmdlets', '', Justification='not available on mac/unix systems, so without faking it, our builds fail')]
+                        param()
+                    }
+                    function Stop-Service {
+                        [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidOverwritingBuiltInCmdlets', '', Justification='not available on mac/unix systems, so without faking it, our builds fail')]
+                        param()
+
+                    }
+                    function Get-CimInstance {
+                        [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidOverwritingBuiltInCmdlets', '', Justification='not available on mac/unix systems, so without faking it, our builds fail')]
+                        param()
+                    }
                 }
             }
 
@@ -367,6 +380,7 @@ try
                 {
                     it "Should call tentacle.exe with args '<line>'" -TestCases $cases {
                         param($line)
+                        write-verbose "Checking line $line" # workaround ReviewUnusedParameter does not capture parameter usage within a scriptblock.  See https://github.com/PowerShell/PSScriptAnalyzer/issues/1472
                         Set-TargetResource @params
                         Assert-MockCalled -CommandName 'Invoke-TentacleCommand' -Times 1 -Exactly -ParameterFilter { ($cmdArgs -join ' ') -eq $line }
                     }

--- a/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
@@ -340,7 +340,6 @@ try
                     function Stop-Service {
                         [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidOverwritingBuiltInCmdlets', '', Justification='not available on mac/unix systems, so without faking it, our builds fail')]
                         param()
-
                     }
                     function Get-CimInstance {
                         [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidOverwritingBuiltInCmdlets', '', Justification='not available on mac/unix systems, so without faking it, our builds fail')]
@@ -349,8 +348,7 @@ try
                 }
             }
 
-            function ConvertTo-Hashtable
-            {
+            function ConvertTo-Hashtable {
                 param (
                     [Parameter(ValueFromPipeline = $true)]
                     [Object[]] $InputObject
@@ -389,7 +387,7 @@ try
 
             Context "New instance" {
                 BeforeAll {
-                    Mock Invoke-TentacleCommand {} -Verifiable #{ write-host "`"$($args[1] -join ' ')`"," } -Verifiable
+                    Mock Invoke-TentacleCommand {} -Verifiable #{ write-host "`"$($cmdArgs -join ' ')`"," } -Verifiable
                     Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstance" }
                     Mock Invoke-MsiExec {} -Verifiable
                     Mock Request-File {} -Verifiable
@@ -419,7 +417,7 @@ try
 
             Context "New polling tentacle" {
                 BeforeAll {
-                    Mock Invoke-TentacleCommand {} #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Invoke-TentacleCommand {} #{ write-host "`"$($cmdArgs -join ' ')`"," }
                     Mock Get-TargetResource { return Get-CurrentConfiguration "NewPollingTentacle" }
                     Mock Invoke-MsiExec { }
                     Mock Request-File {}
@@ -448,7 +446,7 @@ try
 
             Context "New instance in space" {
                 BeforeAll {
-                    Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Invoke-TentacleCommand #{ write-host "`"$(cmdArgs -join ' ')`"," }
                     Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstanceInSpace" }
                     Mock Invoke-MsiExec {}
                     Mock Request-File {}
@@ -477,7 +475,7 @@ try
 
             Context "New Worker" {
                 BeforeAll {
-                    Mock Invoke-TentacleCommand # { write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Invoke-TentacleCommand # { write-host "`"$($cmdArgs -join ' ')`"," }
                     Mock Get-TargetResource { return Get-CurrentConfiguration "NewWorker" }
                     Mock Invoke-MsiExec {}
                     Mock Request-File {}
@@ -508,7 +506,7 @@ try
 
             Context "New Worker in space" {
                 BeforeAll {
-                    Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Invoke-TentacleCommand #{ write-host "`"$($cmdArgs -join ' ')`"," }
                     Mock Get-TargetResource { return Get-CurrentConfiguration "NewWorkerInSpace" }
                     Mock Invoke-MsiExec {}
                     Mock Request-File {}
@@ -538,7 +536,7 @@ try
 
             Context "Install only" {
                 BeforeAll {
-                    Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Invoke-TentacleCommand #{ write-host "`"$($cmdArgs -join ' ')`"," }
                     Mock Get-TargetResource { return Get-CurrentConfiguration "InstallOnly" }
                     Mock Invoke-MsiExec {}
                     Mock Request-File {}
@@ -566,7 +564,7 @@ try
 
             Context "Uninstall running instance" {
                 BeforeAll {
-                    Mock Invoke-TentacleCommand # { write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Invoke-TentacleCommand # { write-host "`"$($cmdArgs -join ' ')`"," }
                     Mock Get-TargetResource { return Get-CurrentConfiguration "UninstallingRunningInstance" }
                     Mock Invoke-MsiExec {}
                     Mock Invoke-MsiUninstall {}
@@ -600,7 +598,7 @@ try
 
             Context "Uninstall running instance (with space)" {
                 BeforeAll {
-                    Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Invoke-TentacleCommand #{ write-host "`"$($cmdArgs -join ' ')`"," }
                     Mock Get-TargetResource { return Get-CurrentConfiguration "UninstallingRunningInstanceInSpace" }
                     Mock Invoke-MsiExec {}
                     Mock Invoke-MsiUninstall {}
@@ -634,7 +632,7 @@ try
 
             Context "Upgrade existing instance" {
                 BeforeAll {
-                    Mock Invoke-TentacleCommand {} #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Invoke-TentacleCommand {} #{ write-host "`"$($cmdArgs -join ' ')`"," }
                     Mock Get-TargetResource { return Get-CurrentConfiguration "UpgradeExistingInstance" }
                     Mock Invoke-MsiExec {}
                     Mock Request-File {}
@@ -667,7 +665,7 @@ try
 
             Context "Upgrade existing instance in space" {
                 BeforeAll {
-                    Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Invoke-TentacleCommand #{ write-host "`"$($cmdArgs -join ' ')`"," }
                     Mock Get-TargetResource { return Get-CurrentConfiguration "UpgradeExistingInstanceInSpace" }
                     Mock Invoke-MsiExec {}
                     Mock Request-File {}

--- a/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
@@ -1,21 +1,25 @@
 #requires -Version 4.0
 
 $moduleName = Split-Path ($PSCommandPath -replace '\.Tests\.ps1$', '') -Leaf
-$modulePath = Split-Path $PSCommandPath -Parent
-$modulePath = Resolve-Path "$PSCommandPath/../../DSCResources/$moduleName/$moduleName.psm1"
+$global:modulePath = Split-Path $PSCommandPath -Parent
+$global:modulePath = Resolve-Path "$PSCommandPath/../../DSCResources/$moduleName/$moduleName.psm1"
+$global:dscHelpersPath = Resolve-Path "$PSCommandPath/../../OctopusDSCHelpers.ps1"
+$global:powershellHelpersPath = Resolve-Path "$PSCommandPath/../../../tests/powershell-helpers.ps1"
 $module = $null
 
 try
 {
     $prefix = [guid]::NewGuid().Guid -replace '-'
-    $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
+    $module = Import-Module $global:modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
 
-        # Get-Service is not available on mac/unix systems - fake it
-        $getServiceCommand = Get-Command "Get-Service" -ErrorAction SilentlyContinue
-        if ($null -eq $getServiceCommand) {
-            function Get-Service {}
+        BeforeAll {
+            # Get-Service is not available on mac/unix systems - fake it
+            $getServiceCommand = Get-Command "Get-Service" -ErrorAction SilentlyContinue
+            if ($null -eq $getServiceCommand) {
+                function Get-Service {}
+            }
         }
 
         Describe 'cTentacleAgent' {
@@ -30,43 +34,55 @@ try
 
             Context 'Test-ParameterSet' {
                 It 'Throws if PublicHostNameConfiguration is Custom but CustomPublicHostName not set' {
-                    { Test-ParameterSet -publicHostNameConfiguration "Custom" -CustomPublicHostName $null -WorkerPools @() -Environments @('My Env') -Roles @() -Tenants @() -TenantTags @()} | Should Throw "Invalid configuration requested"
+                    { Test-ParameterSet -publicHostNameConfiguration "Custom" -CustomPublicHostName $null -WorkerPools @() -Environments @('My Env') -Roles @() -Tenants @() -TenantTags @() } `
+                        | Should -throw "Invalid configuration requested. PublicHostNameConfiguration was set to 'Custom' but an invalid or null CustomPublicHostName was specified."
                 }
                 It 'Throws if WorkerPools are provided and Environments are provided' {
-                    { Test-ParameterSet -publicHostNameConfiguration "PublicIp" -CustomPublicHostName $null -WorkerPools @('My Worker Pool') -Environments @('My Env') -Roles @() -Tenants @() -TenantTags @() } | Should Throw "Invalid configuration requested"
+                    { Test-ParameterSet -publicHostNameConfiguration "PublicIp" -CustomPublicHostName $null -WorkerPools @('My Worker Pool') -Environments @('My Env') -Roles @() -Tenants @() -TenantTags @() } `
+                        | Should -throw "Invalid configuration requested. You have asked for the Tentacle to be registered as a worker, but still provided the 'Environments' configuration argument. Please remove the 'Environments' configuration argument."
                 }
                 It 'Throws if WorkerPools are provided and Roles are provided' {
-                    { Test-ParameterSet -publicHostNameConfiguration "PublicIp" -CustomPublicHostName $null -WorkerPools @('My Worker Pool') -Environments @() -Roles @('My Roles') -Tenants @() -TenantTags @() } | Should Throw "Invalid configuration requested"
+                    { Test-ParameterSet -publicHostNameConfiguration "PublicIp" -CustomPublicHostName $null -WorkerPools @('My Worker Pool') -Environments @() -Roles @('My Roles') -Tenants @() -TenantTags @() } `
+                        | Should -throw "Invalid configuration requested. You have asked for the Tentacle to be registered as a worker, but still provided the 'Roles' configuration argument. Please remove the 'Roles' configuration argument."
                 }
                 It 'Throws if WorkerPools are provided and Tenants are provided' {
-                    { Test-ParameterSet -publicHostNameConfiguration "PublicIp" -CustomPublicHostName $null -WorkerPools @('My Worker Pool') -Environments @() -Roles @() -Tenants @('Jim-Bob') -TenantTags @() } | Should Throw "Invalid configuration requested"
+                    { Test-ParameterSet -publicHostNameConfiguration "PublicIp" -CustomPublicHostName $null -WorkerPools @('My Worker Pool') -Environments @() -Roles @() -Tenants @('Jim-Bob') -TenantTags @() } `
+                        | Should -throw "Invalid configuration requested. You have asked for the Tentacle to be registered as a worker, but still provided the 'Tenants' configuration argument. Please remove the 'Tenants' configuration argument."
                 }
                 It 'Throws if WorkerPools are provided and Tenant Tags are provided' {
-                    { Test-ParameterSet -publicHostNameConfiguration "PublicIp" -CustomPublicHostName $null -WorkerPools @('My Worker Pool') -Environments @() -Roles @() -Tenants @() -TenantTags @('CustomerType/VIP') } | Should Throw "Invalid configuration requested"
+                    { Test-ParameterSet -publicHostNameConfiguration "PublicIp" -CustomPublicHostName $null -WorkerPools @('My Worker Pool') -Environments @() -Roles @() -Tenants @() -TenantTags @('CustomerType/VIP') } `
+                        | Should -throw "Invalid configuration requested. You have asked for the Tentacle to be registered as a worker, but still provided the 'TenantTags' configuration argument. Please remove the 'TenantTags' configuration argument."
                 }
             }
 
             Context 'Confirm-RegistrationParameter' {
                 It 'Throws if RegisterWithServer is false but environment provided' {
-                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False -Environments @('My Env') } | Should Throw "Invalid configuration requested"
+                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False -Environments @('My Env') } `
+                        | Should -throw "Invalid configuration requested. You have asked for the Tentacle not to be registered with the server, but still provided the 'Environments' configuration argument. Please remove the 'Environments' configuration argument or set 'RegisterWithServer = `$True'."
                 }
                 It 'Throws if RegisterWithServer is false but roles provided' {
-                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False -Roles @('app-server') } | Should Throw "Invalid configuration requested"
+                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False -Roles @('app-server') } `
+                        | Should -throw "Invalid configuration requested. You have asked for the Tentacle not to be registered with the server, but still provided the 'Roles' configuration argument. Please remove the 'Roles' configuration argument or set 'RegisterWithServer = `$True'."
                 }
                 It 'Throws if RegisterWithServer is false but tenants provided' {
-                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False -Tenants @('Jim-Bob') } | Should Throw "Invalid configuration requested"
+                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False -Tenants @('Jim-Bob') } `
+                        | Should -throw "Invalid configuration requested. You have asked for the Tentacle not to be registered with the server, but still provided the 'Tenants' configuration argument. Please remove the 'Tenants' configuration argument or set 'RegisterWithServer = `$True'."
                 }
                 It 'Throws if RegisterWithServer is false but tenant Tags provided' {
-                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False -TenantTags @('CustomerType/VIP', 'Hosting/OnPrem') } | Should Throw "Invalid configuration requested"
+                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False -TenantTags @('CustomerType/VIP', 'Hosting/OnPrem') } `
+                        | Should -throw "Invalid configuration requested. You have asked for the Tentacle not to be registered with the server, but still provided the 'TenantTags' configuration argument. Please remove the 'TenantTags' configuration argument or set 'RegisterWithServer = `$True'."
                 }
                 It 'Throws if RegisterWithServer is false but policy provided' {
-                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False -Policy "my policy" } | Should Throw "Invalid configuration requested"
+                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False -Policy "my policy" } `
+                        | Should -throw "Invalid configuration requested. You have asked for the Tentacle not to be registered with the server, but still provided the 'Policy' configuration argument. Please remove the 'Policy' configuration argument or set 'RegisterWithServer = `$True'."
                 }
                 It 'Throws if RegisterWithServer is true but no OctopusServerUrl provided' {
-                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $true -OctopusServerUrl $null } | Should Throw "Invalid configuration requested"
+                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $true -OctopusServerUrl $null } `
+                        | Should -throw "Invalid configuration requested. You have asked for the Tentacle to be registered with the server, but not provided the 'OctopusServerUrl' configuration argument. Please specify the 'OctopusServerUrl' configuration argument or set 'RegisterWithServer = `$False'."
                 }
                 It 'Throws if RegisterWithServer is true but no ApiKey provided' {
-                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $true -OctopusServerUrl "https://example.octopus.com" -ApiKey $null } | Should Throw "Invalid configuration requested"
+                    { Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $true -OctopusServerUrl "https://example.octopus.com" -ApiKey $null } `
+                        | Should -throw "Invalid configuration requested. You have asked for the Tentacle to be registered with the server, but not provided the 'ApiKey' configuration argument. Please specify the 'ApiKey' configuration argument or set 'RegisterWithServer = `$False'."
                 }
                 It 'Does not throw if RegisterWithServer is false and environment provided as empty string' {
                     Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False -Environments ""
@@ -80,20 +96,23 @@ try
                 It 'Does not throw if RegisterWithServer is false and no environment provided' {
                     Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $False
                 }
-                It 'Does not throw if RegisterWithServer is true and OctopusServerUrl and ApiKey     provided' {
+                It 'Does not throw if RegisterWithServer is true and OctopusServerUrl and ApiKey provided' {
                     Confirm-RegistrationParameter -Ensure "Present" -RegisterWithServer $true -OctopusServerUrl "https://example.octopus.com" -ApiKey "API-1234"
                 }
                 It 'Throws if Ensure = absent, RegisterWithServer is true and no ApiKey provided' {
-                    { Confirm-RegistrationParameter -Ensure "Absent" -RegisterWithServer $true -OctopusServerUrl "https://example.octopus.com" -ApiKey $null } | Should Throw "Invalid configuration requested"
+                    { Confirm-RegistrationParameter -Ensure "Absent" -RegisterWithServer $true -OctopusServerUrl "https://example.octopus.com" -ApiKey $null } `
+                        | Should -throw "Invalid configuration requested. You have asked for the Tentacle to be de-registered from the server, but not provided the 'ApiKey' configuration argument. Please specify the 'ApiKey' configuration argument or set 'RegisterWithServer = `$False'."
                 }
             }
 
             Context 'Confirm-RequestedState' {
                 It 'Throws if Ensure is absent but state is started' {
-                    { Confirm-RequestedState @{"Ensure" = "Absent"; "State" = "Started";} } | Should Throw "Invalid configuration requested"
+                    { Confirm-RequestedState @{"Ensure" = "Absent"; "State" = "Started";} } `
+                    | Should -throw "Invalid configuration requested. You have asked for the service to not exist, but also be running at the same time. You probably want 'State = `"Stopped`"'."
                 }
                 It 'Does not throws if Ensure is absent but state not provided' {
-                    { Confirm-RequestedState @{"Ensure" = "Absent";} } | Should Not Throw
+                    { Confirm-RequestedState @{"Ensure" = "Absent";} } `
+                        | Should -not -throw "foo"
                 }
             }
 
@@ -102,7 +121,6 @@ try
                     Mock Get-APIResult { return @( [pscustomobject] @{ Name = "Pool1"; Id = "WorkerPools-1" } )} -ParameterFilter {$api -eq "/workerpools/all"}
                     Mock Get-APIResult { return @( [pscustomobject] @{ Name = "Worker1"; WorkerPoolIds = @("WorkerPools-1"); Thumbprint = "12345678"} )} -ParameterFilter {$api -eq "/workers/all"}
                     $result = Get-WorkerPoolMembership -ServerUrl "https://example.com" -Thumbprint "12345678" -ApiKey "API-1234" -SpaceId $null
-
                     $result.Count | Should -Not -Be $null
                 }
             }
@@ -112,43 +130,47 @@ try
                     Mock Get-APIResult { return @( [pscustomobject] @{ Name = "Pool1"; Id = "WorkerPools-1" } )} -ParameterFilter {$api -eq "/workerpools/all"}
                     Mock Get-APIResult { return @( [pscustomobject] @{ Name = "Worker1"; WorkerPoolIds = @("WorkerPools-1"); Thumbprint = "12345678"} )} -ParameterFilter {$api -eq "/workers/all"}
                     $result = Get-WorkerPoolMembership -ServerUrl "http://localhost:8065" -Thumbprint "D80D5A3DF457E1EFB355451109588DBE26F59368" -ApiKey "API-JM91EXRDGJTCTT7SEEVMJ7E73R4" -SpaceId $null
-
                     $result.GetType() | Should -Be "System.Object[]"
                     $result.Count | Should -Not -Be $null
                 }
             }
 
             Context 'Get-TargetResource' {
-                Mock Get-ItemProperty { return @{ InstallLocation = "c:\Octopus\Tentacle\Stub" }}
-                Mock Get-Service { return @{ Status = "Running" }}
+                BeforeAll {
+                    Mock Get-ItemProperty { return @{ InstallLocation = "c:\Octopus\Tentacle\Stub" }}
+                    Mock Get-Service { return @{ Status = "Running" }}
+                }
 
                 It 'Returns the proper data' {
                     $config = Get-TargetResource -Name 'Stub' -PublicHostNameConfiguration "PublicIp"
-
-                    $config.GetType()                  | Should Be ([hashtable])
-                    $config['Name']                    | Should Be 'Stub'
-                    $config['Ensure']                  | Should Be 'Present'
-                    $config['State']                   | Should Be 'Started'
+                    $config.GetType()                  | Should -Be ([hashtable])
+                    $config['Name']                    | Should -Be 'Stub'
+                    $config['Ensure']                  | Should -Be 'Present'
+                    $config['State']                   | Should -Be 'Started'
                 }
 
                 It "Throws if we specify a null or invalid CustomHostName" {
-                    { Get-TargetResource -Name "Stub" -PublicHostNameConfiguration "Custom" -CustomPublicHostName $null } | Should Throw "invalid or null"
-                    { Get-TargetResource -Name "Stub" -PublicHostNameConfiguration "Custom" -CustomPublicHostName "  " } | Should Throw "invalid or null"
-                    { Get-TargetResource -Name "Stub" -PublicHostNameConfiguration "Custom" -CustomPublicHostName "mydnsname" } | Should Not Throw
+                    { Get-TargetResource -Name "Stub" -PublicHostNameConfiguration "Custom" -CustomPublicHostName $null } `
+                        | Should -throw "Invalid configuration requested. PublicHostNameConfiguration was set to 'Custom' but an invalid or null CustomPublicHostName was specified."
+                    { Get-TargetResource -Name "Stub" -PublicHostNameConfiguration "Custom" -CustomPublicHostName "  " } `
+                        | Should -throw "Invalid configuration requested. PublicHostNameConfiguration was set to 'Custom' but an invalid or null CustomPublicHostName was specified."
+                    { Get-TargetResource -Name "Stub" -PublicHostNameConfiguration "Custom" -CustomPublicHostName "mydnsname" } `
+                        | Should -not -throw
                 }
             }
 
             Context 'Test-TargetResource' {
-                $response = @{ Ensure="Absent"; State="Stopped" }
-                Mock Get-TargetResource { return $response }
+                BeforeAll {
+                    $response = @{ Ensure="Absent"; State="Stopped" }
+                    Mock Get-TargetResource { return $response }
+                }
 
                 It 'Returns True when Ensure is set to Absent and Tentacle does not exist' {
                     $desiredConfiguration['Ensure'] = 'Absent'
                     $desiredConfiguration['State'] = 'Stopped'
                     $response['Ensure'] = 'Absent'
                     $response['State'] = 'Stopped'
-
-                    Test-TargetResource @desiredConfiguration | Should Be $true
+                    Test-TargetResource @desiredConfiguration | Should -Be $true
                 }
 
                It 'Returns True when Ensure is set to Present and Tentacle exists' {
@@ -165,7 +187,6 @@ try
                     }
                     $response['Ensure'] = 'Present'
                     $response['State'] = 'Started'
-
                     # Declare mock objects
                     $mockMachine = @{
                         Name = "MockMachine"
@@ -173,7 +194,6 @@ try
                         WorkerPools = @()
                         Roles = @()
                     }
-
                     # Declare mock calls
                     Mock Get-MachineFromOctopusServer {return $mockMachine}
                     Mock Get-APIResult {return [string]::Empty}
@@ -181,7 +201,7 @@ try
                     Mock Get-Space { return @{
                         "Id" = "Spaces-1"
                     }}
-                    Test-TargetResource @desiredConfiguration | Should Be $true
+                    Test-TargetResource @desiredConfiguration | Should -Be $true
                 }
 
                 It 'Throws an error when space does not exist' {
@@ -198,7 +218,6 @@ try
                     }
                     $response['Ensure'] = 'Present'
                     $response['State'] = 'Started'
-
                     # Declare mock objects
                     $mockMachine = @{
                         Name = "MockMachine"
@@ -206,13 +225,12 @@ try
                         WorkerPools = @()
                         Roles = @()
                     }
-
                     # Declare mock calls
                     Mock Get-MachineFromOctopusServer {return $mockMachine}
                     Mock Get-APIResult {return [string]::Empty}
                     Mock Get-TentacleThumbprint { return "ABCDE123456" }
                     Mock Get-Space { return $null}
-                    { Test-TargetResource @desiredConfiguration } | Should -Throw -ExpectedMessage "Unable to find a space by the name of"
+                    { Test-TargetResource @desiredConfiguration } | Should -Throw -ExpectedMessage "Unable to find a space by the name of 'NonExistentSpace'"
                 }
 
                 It 'Returns true when space exists' {
@@ -229,7 +247,6 @@ try
                     }
                     $response['Ensure'] = 'Present'
                     $response['State'] = 'Started'
-
                     # Declare mock objects
                     $mockMachine = @{
                         Name = "MockMachine"
@@ -237,13 +254,12 @@ try
                         WorkerPools = @()
                         Roles = @()
                     }
-
                     # Declare mock calls
                     Mock Get-MachineFromOctopusServer {return $mockMachine}
                     Mock Get-APIResult {return [string]::Empty}
                     Mock Get-TentacleThumbprint { return "ABCDE123456" }
                     Mock Get-Space { return "Spaces-1"}
-                    { Test-TargetResource @desiredConfiguration } | Should Be $true
+                    { Test-TargetResource @desiredConfiguration } | Should -Be $true
                 }
             }
 
@@ -255,353 +271,403 @@ try
         }
 
         Describe "Testing Get-MyPublicIPAddress" {
-            $testIP = "54.121.34.56"
-            Mock Invoke-RestMethod { return $testIP }
+            BeforeAll {
+                $testIP = "54.121.34.56"
+                Mock Invoke-RestMethod { return $testIP }
+            }
 
             Context "First option works" {
                 It "Should return an IPv4 address" {
-                    Get-MyPublicIPAddress | Should Be $testIP
+                    Get-MyPublicIPAddress | Should -Be $testIP
                 }
             }
 
             Context "First option is down" {
-                Mock Invoke-RestMethod { throw } -ParameterFilter { $uri -eq "https://api.ipify.org/"}
                 It "Should return an IPv4 address" {
-                    Get-MyPublicIPAddress | Should Be $testIP
+                    Mock Invoke-RestMethod { throw } -ParameterFilter { $uri -eq "https://api.ipify.org/"}
+                    Get-MyPublicIPAddress | Should -Be $testIP
                 }
             }
 
             Context "First and Second Options are down" {
-                Mock Invoke-RestMethod { throw } -ParameterFilter { $uri -eq "https://api.ipify.org/" -or $uri -eq 'https://canhazip.com/'}
                 It "Should return an IPv4 address" {
-                    Get-MyPublicIPAddress | Should Be $testIP
+                    Mock Invoke-RestMethod { throw } -ParameterFilter { $uri -eq "https://api.ipify.org/" -or $uri -eq 'https://canhazip.com/'}
+                    Get-MyPublicIPAddress | Should -Be $testIP
                 }
             }
 
-            Context "All three are down, should throw" {
-                Mock Invoke-RestMethod { throw }
+            Context "All three are down, Should -throw" {
                 It "Should throw" {
-                    { Get-MyPublicIPAddress } | Should Throw "Unable to determine"
+                    Mock Invoke-RestMethod { throw }
+                    { Get-MyPublicIPAddress } | Should -throw "Unable to determine your Public IP address. Please supply a hostname or IP address via the PublicHostName parameter."
                 }
             }
 
             Context "A service returns an invalid IP" {
-                Mock Invoke-RestMethod { return "IAMNOTANIPADDRESS" }
-                It "Should Throw" {
-                      { Get-MyPublicIpAddress } | Should Throw "couldn't parse"
+                It "Should throw" {
+                    Mock Invoke-RestMethod { return "IAMNOTANIPADDRESS" }
+                    { Get-MyPublicIpAddress } | Should -throw "Detected Public IP address 'IAMNOTANIPADDRESS', but we we couldn't parse it as an IPv4 address."
                 }
             }
         }
 
         Context "Tentacle command line" {
-            function Get-CurrentConfiguration ([string] $testName) {
-                & (Resolve-Path "$PSCommandPath/../../Tests/TentacleExeInvocationFiles/$testName/CurrentState.ps1")
-            }
+            BeforeAll {
+                . $global:dscHelpersPath
 
-            function Get-RequestedConfiguration ([string] $testName) {
-                & (Resolve-Path "$PSCommandPath/../../Tests/TentacleExeInvocationFiles/$testName/RequestedState.ps1")
+                function Get-CurrentConfiguration ([string] $testName) {
+                    & (Resolve-Path "$PSCommandPath/../../Tests/TentacleExeInvocationFiles/$testName/CurrentState.ps1")
+                }
+
+                function Get-RequestedConfiguration ([string] $testName) {
+                    & (Resolve-Path "$PSCommandPath/../../Tests/TentacleExeInvocationFiles/$testName/RequestedState.ps1")
+                }
+
+                function Get-TempFolder {
+                    if ("$($env:TmpDir)" -ne "") {
+                        return $env:TmpDir
+                    } else {
+                        return $env:Temp
+                    }
+                }
+
+                # create stubs for these cmdlets on linux/mac as they dont natively exist
+                # leading to pester complaining that it cant mock it...
+                if (-not $isWindows) {
+                    function Start-Service {}
+                    function Stop-Service {}
+                    function Get-CimInstance {}
+                }
             }
 
             function Assert-ExpectedResult ([string] $testName) {
-                # todo: test order of execution here
+                . $global:powershellHelpersPath
+
+                # todo: test order of execution here as well
                 $invocations = & (Resolve-Path "$PSCommandPath/../../Tests/TentacleExeInvocationFiles/$testName/ExpectedResult.ps1")
+                $name = @{label="line";expression={$_}};
+                $cases = @($invocations | select-object -Property $name) | ConvertTo-HashTable
+
                 it "Should call tentacle.exe $($invocations.count) times" {
                     Assert-MockCalled -CommandName 'Invoke-TentacleCommand' -Times $invocations.Count -Exactly
                 }
-                foreach($line in $invocations) {
-                    It "Should call tentacle.exe with args '$line'" {
-                        Assert-MockCalled -CommandName 'Invoke-TentacleCommand' -Times 1 -Exactly -ParameterFilter { ($arguments -join ' ') -eq $line }
+                if ($cases.length -gt 0)
+                {
+                    it "Should call tentacle.exe with args '<line>'" -TestCases $cases {
+                        param($line)
+                        Set-TargetResource @params
+                        Assert-MockCalled -CommandName 'Invoke-TentacleCommand' -Times 1 -Exactly -ParameterFilter { ($cmdArgs -join ' ') -eq $line }
                     }
                 }
             }
 
-            function Get-TempFolder {
-                if ("$($env:TmpDir)" -ne "") {
-                    return $env:TmpDir
-                } else {
-                    return $env:Temp
-                }
-            }
-
-            # create stubs for these cmdlets on linux/mac as they dont natively exist
-            # leading to pester complaining that it cant mock it...
-            if (-not $isWindows) {
-                function Start-Service {}
-                function Stop-Service {}
-                function Get-CimInstance {}
-            }
-
             Context "New instance" {
-                Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
-                Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstance" }
-                Mock Invoke-MsiExec {}
-                Mock Request-File {}
-                Mock Update-InstallState {}
-                Mock Invoke-AndAssert {}
-                Mock Start-Service {}
-                Mock Get-PublicHostName { return "mytestserver.local"; }
-                Mock New-Item {}
-
-                $params = Get-RequestedConfiguration "NewInstance"
-                Set-TargetResource @params
-
+                BeforeAll {
+                    Mock Invoke-TentacleCommand {} -Verifiable #{ write-host "`"$($args[1] -join ' ')`"," } -Verifiable
+                    Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstance" }
+                    Mock Invoke-MsiExec {} -Verifiable
+                    Mock Request-File {} -Verifiable
+                    Mock Update-InstallState {}
+                    Mock Invoke-AndAssert {}
+                    Mock Start-Service {} -Verifiable
+                    Mock Get-PublicHostName { return "mytestserver.local"; }
+                    Mock New-Item {}
+                    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
+                    $params = Get-RequestedConfiguration "NewInstance"
+                }
                 Assert-ExpectedResult "NewInstance"
+
                 it "Should download the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Request-File
                 }
                 it "Should install the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Invoke-MsiExec
                 }
                 it "Should start the service" {
+                    Set-TargetResource @params
                     Assert-MockCalled Start-Service
                 }
             }
 
             Context "New polling tentacle" {
-                Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
-                Mock Get-TargetResource { return Get-CurrentConfiguration "NewPollingTentacle" }
-                Mock Invoke-MsiExec {}
-                Mock Request-File {}
-                Mock Update-InstallState {}
-                Mock Invoke-AndAssert {}
-                Mock Start-Service {}
-                Mock Get-PublicHostName { return "mytestserver.local"; }
-                Mock New-Item {}
-
-                $params = Get-RequestedConfiguration "NewPollingTentacle"
-                Set-TargetResource @params
-
+                BeforeAll {
+                    Mock Invoke-TentacleCommand {} #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Get-TargetResource { return Get-CurrentConfiguration "NewPollingTentacle" }
+                    Mock Invoke-MsiExec { }
+                    Mock Request-File {}
+                    Mock Update-InstallState {}
+                    Mock Invoke-AndAssert {}
+                    Mock Start-Service {}
+                    Mock Get-PublicHostName { return "mytestserver.local"; }
+                    Mock New-Item {}
+                    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
+                    $params = Get-RequestedConfiguration "NewPollingTentacle"
+                }
                 Assert-ExpectedResult "NewPollingTentacle"
                 it "Should download the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Request-File
                 }
                 it "Should install the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Invoke-MsiExec
                 }
                 it "Should start the service" {
+                    Set-TargetResource @params
                     Assert-MockCalled Start-Service
                 }
             }
 
             Context "New instance in space" {
-                Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
-                Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstanceInSpace" }
-                Mock Invoke-MsiExec {}
-                Mock Request-File {}
-                Mock Update-InstallState {}
-                Mock Invoke-AndAssert {}
-                Mock Start-Service {}
-                Mock Get-PublicHostName { return "mytestserver.local"; }
-                Mock New-Item {}
-
-                $params = Get-RequestedConfiguration "NewInstanceInSpace"
-                Set-TargetResource @params
-
+                BeforeAll {
+                    Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Get-TargetResource { return Get-CurrentConfiguration "NewInstanceInSpace" }
+                    Mock Invoke-MsiExec {}
+                    Mock Request-File {}
+                    Mock Update-InstallState {}
+                    Mock Invoke-AndAssert {}
+                    Mock Start-Service {}
+                    Mock Get-PublicHostName { return "mytestserver.local"; }
+                    Mock New-Item {}
+                    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
+                    $params = Get-RequestedConfiguration "NewInstanceInSpace"
+                }
                 Assert-ExpectedResult "NewInstanceInSpace"
                 it "Should download the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Request-File
                 }
                 it "Should install the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Invoke-MsiExec
                 }
                 it "Should start the service" {
+                    Set-TargetResource @params
                     Assert-MockCalled Start-Service
                 }
             }
 
             Context "New Worker" {
-                Mock Invoke-TentacleCommand # { write-host "`"$($args[1] -join ' ')`"," }
-                Mock Get-TargetResource { return Get-CurrentConfiguration "NewWorker" }
-                Mock Invoke-MsiExec {}
-                Mock Request-File {}
-                Mock Update-InstallState {}
-                Mock Invoke-AndAssert {}
-                Mock Start-Service {}
-                Mock Get-PublicHostName { return "mytestserver.local"; }
-                Mock New-Item {}
-                Mock Test-TentacleExecutableExists { return $true }
-
-                $params = Get-RequestedConfiguration "NewWorker"
-                Set-TargetResource @params
-
+                BeforeAll {
+                    Mock Invoke-TentacleCommand # { write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Get-TargetResource { return Get-CurrentConfiguration "NewWorker" }
+                    Mock Invoke-MsiExec {}
+                    Mock Request-File {}
+                    Mock Update-InstallState {}
+                    Mock Invoke-AndAssert {}
+                    Mock Start-Service {}
+                    Mock Get-PublicHostName { return "mytestserver.local"; }
+                    Mock New-Item {}
+                    Mock Test-TentacleExecutableExists { return $true }
+                    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
+                    $params = Get-RequestedConfiguration "NewWorker"
+                }
                 Assert-ExpectedResult "NewWorker"
+
                 it "Should download the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Request-File
                 }
                 it "Should install the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Invoke-MsiExec
                 }
                 it "Should start the service" {
+                    Set-TargetResource @params
                     Assert-MockCalled Start-Service
                 }
             }
 
             Context "New Worker in space" {
-                Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
-                Mock Get-TargetResource { return Get-CurrentConfiguration "NewWorkerInSpace" }
-                Mock Invoke-MsiExec {}
-                Mock Request-File {}
-                Mock Update-InstallState {}
-                Mock Invoke-AndAssert {}
-                Mock Start-Service {}
-                Mock Get-PublicHostName { return "mytestserver.local"; }
-                Mock New-Item {}
-                Mock Test-TentacleExecutableExists { return $true }
-
-                $params = Get-RequestedConfiguration "NewWorkerInSpace"
-                Set-TargetResource @params
-
+                BeforeAll {
+                    Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Get-TargetResource { return Get-CurrentConfiguration "NewWorkerInSpace" }
+                    Mock Invoke-MsiExec {}
+                    Mock Request-File {}
+                    Mock Update-InstallState {}
+                    Mock Invoke-AndAssert {}
+                    Mock Start-Service {}
+                    Mock Get-PublicHostName { return "mytestserver.local"; }
+                    Mock New-Item {}
+                    Mock Test-TentacleExecutableExists { return $true }
+                    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
+                    $params = Get-RequestedConfiguration "NewWorkerInSpace"
+                }
                 Assert-ExpectedResult "NewWorkerInSpace"
                 it "Should download the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Request-File
                 }
                 it "Should install the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Invoke-MsiExec
                 }
                 it "Should start the service" {
+                    Set-TargetResource @params
                     Assert-MockCalled Start-Service
                 }
             }
 
             Context "Install only" {
-                Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
-                Mock Get-TargetResource { return Get-CurrentConfiguration "InstallOnly" }
-                Mock Invoke-MsiExec {}
-                Mock Request-File {}
-                Mock Update-InstallState {}
-                Mock Invoke-AndAssert {}
-                Mock Start-Service {}
-                Mock New-Item {}
-
-                $params = Get-RequestedConfiguration "InstallOnly"
-                Set-TargetResource @params
-
+                BeforeAll {
+                    Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Get-TargetResource { return Get-CurrentConfiguration "InstallOnly" }
+                    Mock Invoke-MsiExec {}
+                    Mock Request-File {}
+                    Mock Update-InstallState {}
+                    Mock Invoke-AndAssert {}
+                    Mock Start-Service {}
+                    Mock New-Item {}
+                    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
+                    $params = Get-RequestedConfiguration "InstallOnly"
+                }
                 Assert-ExpectedResult "InstallOnly"
                 it "Should download the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Request-File
                 }
                 it "Should install the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Invoke-MsiExec
                 }
                 it "Should start not the service" {
+                    Set-TargetResource @params
                     Assert-MockCalled Start-Service -times 0
                 }
             }
 
             Context "Uninstall running instance" {
-                Mock Invoke-TentacleCommand # { write-host "`"$($args[1] -join ' ')`"," }
-                Mock Get-TargetResource { return Get-CurrentConfiguration "UninstallingRunningInstance" }
-                Mock Invoke-MsiExec {}
-                Mock Invoke-MsiUninstall {}
-                Mock Request-File {}
-                Mock Update-InstallState {}
-                Mock Invoke-AndAssert {}
-                Mock Start-Service {}
-                Mock Get-CimInstance { return @() } # no other instances on the box
-                Mock Test-TentacleExecutableExists { return $true }
-
-                $params = Get-RequestedConfiguration "UninstallingRunningInstance"
-                Set-TargetResource @params
-
+                BeforeAll {
+                    Mock Invoke-TentacleCommand # { write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Get-TargetResource { return Get-CurrentConfiguration "UninstallingRunningInstance" }
+                    Mock Invoke-MsiExec {}
+                    Mock Invoke-MsiUninstall {}
+                    Mock Request-File {}
+                    Mock Update-InstallState {}
+                    Mock Invoke-AndAssert {}
+                    Mock Start-Service {}
+                    Mock Get-CimInstance { return @() } # no other instances on the box
+                    Mock Test-TentacleExecutableExists { return $true }
+                    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
+                    $params = Get-RequestedConfiguration "UninstallingRunningInstance"
+                }
                 Assert-ExpectedResult "UninstallingRunningInstance"
                 it "Should not download the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Request-File -times 0
                 }
                 it "Should not install the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Invoke-MsiExec -times 0
                 }
                 it "Should uninstall the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Invoke-MsiUninstall
                 }
                 it "Should not start the service" {
+                    Set-TargetResource @params
                     Assert-MockCalled Start-Service -times 0
                 }
             }
 
             Context "Uninstall running instance (with space)" {
-                Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
-                Mock Get-TargetResource { return Get-CurrentConfiguration "UninstallingRunningInstanceInSpace" }
-                Mock Invoke-MsiExec {}
-                Mock Invoke-MsiUninstall {}
-                Mock Request-File {}
-                Mock Update-InstallState {}
-                Mock Invoke-AndAssert {}
-                Mock Start-Service {}
-                Mock Get-CimInstance { return @() } # no other instances on the box
-                Mock Test-TentacleExecutableExists { return $true }
-
-                $params = Get-RequestedConfiguration "UninstallingRunningInstanceInSpace"
-                Set-TargetResource @params
-
+                BeforeAll {
+                    Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Get-TargetResource { return Get-CurrentConfiguration "UninstallingRunningInstanceInSpace" }
+                    Mock Invoke-MsiExec {}
+                    Mock Invoke-MsiUninstall {}
+                    Mock Request-File {}
+                    Mock Update-InstallState {}
+                    Mock Invoke-AndAssert {}
+                    Mock Start-Service {}
+                    Mock Get-CimInstance { return @() } # no other instances on the box
+                    Mock Test-TentacleExecutableExists { return $true }
+                    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
+                    $params = Get-RequestedConfiguration "UninstallingRunningInstanceInSpace"
+                }
                 Assert-ExpectedResult "UninstallingRunningInstanceInSpace"
                 it "Should not download the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Request-File -times 0
                 }
                 it "Should not install the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Invoke-MsiExec -times 0
                 }
                 it "Should uninstall the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Invoke-MsiUninstall
                 }
                 it "Should not start the service" {
+                    Set-TargetResource @params
                     Assert-MockCalled Start-Service -times 0
                 }
             }
 
             Context "Upgrade existing instance" {
-                Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
-                Mock Get-TargetResource { return Get-CurrentConfiguration "UpgradeExistingInstance" }
-                Mock Invoke-MsiExec {}
-                Mock Request-File {}
-                Mock Update-InstallState {}
-                Mock Invoke-AndAssert {}
-                Mock Start-Service {}
-                Mock Stop-Service {}
-                Mock New-Item {}
-
-                $params = Get-RequestedConfiguration "UpgradeExistingInstance"
-                Set-TargetResource @params
-
+                BeforeAll {
+                    Mock Invoke-TentacleCommand {} #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Get-TargetResource { return Get-CurrentConfiguration "UpgradeExistingInstance" }
+                    Mock Invoke-MsiExec {}
+                    Mock Request-File {}
+                    Mock Update-InstallState {}
+                    Mock Invoke-AndAssert {}
+                    Mock Start-Service {}
+                    Mock Stop-Service {}
+                    Mock New-Item {}
+                    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
+                    $params = Get-RequestedConfiguration "UpgradeExistingInstance"
+                }
                 Assert-ExpectedResult "UpgradeExistingInstance"
                 it "Should download the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Request-File
                 }
                 it "Should install the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Invoke-MsiExec
                 }
                 it "Should start the service" {
+                    Set-TargetResource @params
                     Assert-MockCalled Start-Service
                 }
                 it "Should stop the service" {
+                    Set-TargetResource @params
                     Assert-MockCalled Stop-Service
                 }
             }
 
             Context "Upgrade existing instance in space" {
-                Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
-                Mock Get-TargetResource { return Get-CurrentConfiguration "UpgradeExistingInstanceInSpace" }
-                Mock Invoke-MsiExec {}
-                Mock Request-File {}
-                Mock Update-InstallState {}
-                Mock Invoke-AndAssert {}
-                Mock Start-Service {}
-                Mock Stop-Service {}
-                Mock New-Item {}
-
-                $params = Get-RequestedConfiguration "UpgradeExistingInstanceInSpace"
-                Set-TargetResource @params
-
+                BeforeAll {
+                    Mock Invoke-TentacleCommand #{ write-host "`"$($args[1] -join ' ')`"," }
+                    Mock Get-TargetResource { return Get-CurrentConfiguration "UpgradeExistingInstanceInSpace" }
+                    Mock Invoke-MsiExec {}
+                    Mock Request-File {}
+                    Mock Update-InstallState {}
+                    Mock Invoke-AndAssert {}
+                    Mock Start-Service {}
+                    Mock Stop-Service {}
+                    Mock New-Item {}
+                    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "", Justification = "It is actually used, but pester's scoping is weird")]
+                    $params = Get-RequestedConfiguration "UpgradeExistingInstanceInSpace"
+                }
                 Assert-ExpectedResult "UpgradeExistingInstanceInSpace"
                 it "Should download the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Request-File
                 }
                 it "Should install the MSI" {
+                    Set-TargetResource @params
                     Assert-MockCalled Invoke-MsiExec
                 }
                 it "Should start the service" {
+                    Set-TargetResource @params
                     Assert-MockCalled Start-Service
                 }
                 it "Should stop the service" {
+                    Set-TargetResource @params
                     Assert-MockCalled Stop-Service
                 }
             }

--- a/OctopusDSC/Tests/cTentacleWatchdog.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleWatchdog.Tests.ps1
@@ -102,12 +102,8 @@ try
             }
 
             Context 'Set-TargetResource' {
-                BeforeAll {
-                    . $dscHelpersPath
-                }
                 It 'Calls Invoke-TentacleCommand with the correct arguments to enable' {
                     Mock Invoke-TentacleCommand
-
                     Set-TargetResource -InstanceName 'SuperTentacle' `
                                        -Enabled $true `
                                        -Interval 5 `
@@ -117,12 +113,11 @@ try
 
                 It 'Calls Invoke-TentacleCommand with the correct arguments to disable' {
                     Mock Invoke-TentacleCommand
-
                     Set-TargetResource -InstanceName 'SuperTentacle' `
                                        -Enabled $false `
                                        -Interval 5 `
                                        -Instances "*"
-                    Assert-MockCalled Invoke-TentacleCommand -ParameterFilter { ($cmdArgs -join ' ') -eq 'watchdog --delete'}
+                    Assert-MockCalled Invoke-TentacleCommand -ParameterFilter { ($cmdArgs -join ' ') -eq 'watchdog --delete' }
                 }
             }
         }

--- a/Tests/OctopusDSC.Tests.ps1
+++ b/Tests/OctopusDSC.Tests.ps1
@@ -51,7 +51,6 @@ Describe "PSScriptAnalyzer" {
                 #even though it works fine on ubuntu locally
                 Set-ItResult -Inconclusive -Because "We couldnt get this test to run on our CentOS buildagent"
             } else {
-
                 $path = Resolve-Path "$PSCommandPath/../../Tests/Scenarios"
                 Write-Output "Running PsScriptAnalyzer against $path"
                 $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude @('PSUseShouldProcessForStateChangingFunctions', 'PSAvoidUsingConvertToSecureStringWithPlainText'))
@@ -72,12 +71,21 @@ Describe "PSScriptAnalyzer" {
         }
 
         It "Should have zero PSScriptAnalyzer issues in Examples" {
-            $path = Resolve-Path "$PSCommandPath/../../OctopusDSC/Examples"
-            Write-Output "Running PsScriptAnalyzer against $path"
-            $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude @('PSUseShouldProcessForStateChangingFunctions', 'PSAvoidUsingConvertToSecureStringWithPlainText'))
-            $results | ConvertTo-Json | Out-File PsScriptAnalyzer-Examples.log
+            $isRunningUnderTeamCity = (Test-Path Env:\TEAMCITY_PROJECT_NAME)
+            if ($isRunningUnderTeamCity) {
+                #unfortunately, cant get the following tests to run on our CentOS buildagent
+                #keep getting:
+                # "Undefined DSC resource 'cOctopusServer'. Use Import-DSCResource to import the resource."
+                #even though it works fine on ubuntu locally
+                Set-ItResult -Inconclusive -Because "We couldnt get this test to run on our CentOS buildagent"
+            } else {
+                $path = Resolve-Path "$PSCommandPath/../../OctopusDSC/Examples"
+                Write-Output "Running PsScriptAnalyzer against $path"
+                $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude @('PSUseShouldProcessForStateChangingFunctions', 'PSAvoidUsingConvertToSecureStringWithPlainText'))
+                $results | ConvertTo-Json | Out-File PsScriptAnalyzer-Examples.log
 
-            $results.length | Should -Be 0
+                $results.length | Should -Be 0
+            }
         }
     }
 }

--- a/Tests/OctopusDSC.Tests.ps1
+++ b/Tests/OctopusDSC.Tests.ps1
@@ -8,7 +8,10 @@ Describe "PSScriptAnalyzer" {
     It "Should have zero PSScriptAnalyzer issues in OctopusDSC/DSCResources" {
         $path = Resolve-Path "$PSCommandPath/../../OctopusDSC/DSCResources"
         Write-Output "Running PsScriptAnalyzer against $path"
-        $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude @('PSUseShouldProcessForStateChangingFunctions'))
+        $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude @(
+            'PSUseShouldProcessForStateChangingFunctions'
+            'PSReviewUnusedParameter' # too many false positives from https://github.com/PowerShell/PSScriptAnalyzer/issues/1472
+            ))
         $results | ConvertTo-Json | Out-File PsScriptAnalyzer-DSCResources.log
 
         $results.length | Should -Be 0

--- a/Tests/OctopusDSC.Tests.ps1
+++ b/Tests/OctopusDSC.Tests.ps1
@@ -1,77 +1,81 @@
-$path = Join-Path -Path $PSScriptRoot -ChildPath "powershell-helpers.ps1"
-. $path
+$script:scriptRoot = $PSScriptRoot
 
 Describe "PSScriptAnalyzer" {
-    Import-PowerShellModule -Name PSScriptAnalyzer -MinimumVersion "1.18.3"
-    $excludedRules = @(
-        'PSUseShouldProcessForStateChangingFunctions'
-    )
+    BeforeAll {
+        . (Join-Path -Path $PSScriptRoot -ChildPath "powershell-helpers.ps1")
+    }
 
     It "Should have zero PSScriptAnalyzer issues in OctopusDSC/DSCResources" {
         $path = Resolve-Path "$PSCommandPath/../../OctopusDSC/DSCResources"
         Write-Output "Running PsScriptAnalyzer against $path"
-        $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude $excludedRules)
+        $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude @('PSUseShouldProcessForStateChangingFunctions'))
         $results | ConvertTo-Json | Out-File PsScriptAnalyzer-DSCResources.log
 
-        $results.length | Should Be 0
+        $results.length | Should -Be 0
     }
 
     It "Should have zero PSScriptAnalyzer issues in OctopusDSC/Tests" {
         $path = Resolve-Path "$PSCommandPath/../../OctopusDSC/Tests"
         Write-Output "Running PsScriptAnalyzer against $path"
-        $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude $excludedRules)
+        $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude @('PSUseShouldProcessForStateChangingFunctions'))
         $results | ConvertTo-Json | Out-File PsScriptAnalyzer-Tests.log
 
-        $results.length | Should Be 0
+        $results.length | Should -Be 0
     }
 
-    #unfortunately, cant get the following tests to run on our CentOS buildagent
-    #keep getting:
-    # "Undefined DSC resource 'cOctopusServer'. Use Import-DSCResource to import the resource."
-    #even though it works fine on ubuntu locally
-    $isRunningUnderTeamCity = (Test-Path Env:\TEAMCITY_PROJECT_NAME)
-    if (-not $isRunningUnderTeamCity)
-    {
-        $existingPSModulePath = $env:PSModulePath
-        $path = Resolve-Path "$PSCommandPath/../../"
-        if ($isLinux -or $IsMacOS) {
-            $newPath = "$($env:PSModulePath):$path"
-        } else {
-            $newPath = "$($env:PSModulePath);$path"
-        }
-        Write-Output "Setting `$env:PSModulePath to '$newPath'"
-        $env:PSModulePath = $newPath
-
-        $excludedRules += 'PSAvoidUsingConvertToSecureStringWithPlainText'
-
-        It "Should have zero PSScriptAnalyzer issues in Scenarios" {
-            $path = Resolve-Path "$PSCommandPath/../../Tests/Scenarios"
-            Write-Output "Running PsScriptAnalyzer against $path"
-            $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude $excludedRules)
-            $results | ConvertTo-Json | Out-File PsScriptAnalyzer-Scenarios.log
-            if ($IsLinux -or $IsMacOS) {
-                $results = $results | where-object {
-                    # these DSC resources are available on linux
-                    ($_.Message -ne "Undefined DSC resource 'LocalConfigurationManager'. Use Import-DSCResource to import the resource.") -and
-                    ($_.Message -ne "Undefined DSC resource 'Script'. Use Import-DSCResource to import the resource.") -and
-                    ($_.Message -ne "Undefined DSC resource 'User'. Use Import-DSCResource to import the resource.") -and
-                    ($_.Message -ne "Undefined DSC resource 'Group'. Use Import-DSCResource to import the resource.") -and
-                    # it's getting confused - Group here is actually the DSC resource, not an alias.
-                    ($_.Message -ne "'Group' is an alias of 'Group-Object'. Alias can introduce possible problems and make scripts hard to maintain. Please consider changing alias to its full content.")
-                }
+    Context "Scenarios" {
+        $script:existingPSModulePath = ""
+        BeforeAll {
+            $script:existingPSModulePath = $env:PSModulePath
+            $path = Resolve-Path "$PSCommandPath/../../"
+            if ($isLinux -or $IsMacOS) {
+                $newPath = "$($env:PSModulePath):$path"
+            } else {
+                $newPath = "$($env:PSModulePath);$path"
             }
-            $results.length | Should Be 0
+            Write-Output "Setting `$env:PSModulePath to '$newPath'"
+            $env:PSModulePath = $newPath
+        }
+        AfterAll {
+            $env:PSModulePath = $script:existingPSModulePath
+        }
+        It "Should have zero PSScriptAnalyzer issues in Scenarios" {
+            $isRunningUnderTeamCity = (Test-Path Env:\TEAMCITY_PROJECT_NAME)
+            if ($isRunningUnderTeamCity) {
+                #unfortunately, cant get the following tests to run on our CentOS buildagent
+                #keep getting:
+                # "Undefined DSC resource 'cOctopusServer'. Use Import-DSCResource to import the resource."
+                #even though it works fine on ubuntu locally
+                Set-ItResult -Inconclusive -Because "We couldnt get this test to run on our CentOS buildagent"
+            } else {
+
+                $path = Resolve-Path "$PSCommandPath/../../Tests/Scenarios"
+                Write-Output "Running PsScriptAnalyzer against $path"
+                $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude @('PSUseShouldProcessForStateChangingFunctions', 'PSAvoidUsingConvertToSecureStringWithPlainText'))
+                $results | ConvertTo-Json | Out-File PsScriptAnalyzer-Scenarios.log
+                if ($IsLinux -or $IsMacOS) {
+                    $results = $results | where-object {
+                        # these DSC resources are available on linux
+                        ($_.Message -ne "Undefined DSC resource 'LocalConfigurationManager'. Use Import-DSCResource to import the resource.") -and
+                        ($_.Message -ne "Undefined DSC resource 'Script'. Use Import-DSCResource to import the resource.") -and
+                        ($_.Message -ne "Undefined DSC resource 'User'. Use Import-DSCResource to import the resource.") -and
+                        ($_.Message -ne "Undefined DSC resource 'Group'. Use Import-DSCResource to import the resource.") -and
+                        # it's getting confused - Group here is actually the DSC resource, not an alias.
+                        ($_.Message -ne "'Group' is an alias of 'Group-Object'. Alias can introduce possible problems and make scripts hard to maintain. Please consider changing alias to its full content.")
+                    }
+                }
+                $results.length | Should -Be 0
+            }
         }
 
         It "Should have zero PSScriptAnalyzer issues in Examples" {
             $path = Resolve-Path "$PSCommandPath/../../OctopusDSC/Examples"
             Write-Output "Running PsScriptAnalyzer against $path"
-            $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude $excludedRules)
+            $results = @(Invoke-ScriptAnalyzer $path -recurse -exclude @('PSUseShouldProcessForStateChangingFunctions', 'PSAvoidUsingConvertToSecureStringWithPlainText'))
             $results | ConvertTo-Json | Out-File PsScriptAnalyzer-Examples.log
 
-            $results.length | Should Be 0
+            $results.length | Should -Be 0
         }
-        $env:PSModulePath = $existingPSModulePath
     }
 }
 
@@ -84,139 +88,120 @@ Describe "OctopusDSC.psd1" {
 
         $expected = ($Data.DscResourcesToExport | Sort-Object) -join ","
         $actual = (($modules.Name | Sort-Object) -join ",")
-        $actual | should be $expected
+        $actual | Should -Be $expected
     }
 }
 
 Describe "Mandatory Parameters" {
+    . (Join-Path -Path $script:scriptRoot -ChildPath "powershell-helpers.ps1")
+
+    $parseErrorTestCases = @()
+    $mandatoryParamTestCases = @()
+    $nonMandatoryParamTestCases = @()
+
     $path = Resolve-Path "$PSCommandPath/../../OctopusDSC/DSCResources"
     $schemaMofFiles = Get-ChildItem $path -Recurse -Filter *.mof
     foreach ($schemaMofFile in $schemaMofFiles) {
         $schemaMofFileContent = Get-Content $schemaMofFile.FullName
         $moduleFile = Get-Item ($schemaMofFile.FullName -replace ".schema.mof", ".psm1")
+        $tokens = $null;
+        $parseErrors = $null;
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($moduleFile.FullName, [ref] $tokens, [ref] $parseErrors);
+        $filter = { $true }
+        $astMembers = $ast.FindAll($filter, $true);
 
-        function Get-ParameterFromFunction($functionName, $astMembers, $propertyName) {
-            $foundMatchingParameter = $false
-            foreach($param in $astMembers) {
-                if ($null -ne $param.name -and $param.Name.ToString() -eq "`$$propertyName") {
-                    $function = $param.Parent.Parent.Parent
-                    if ($function -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
-                        $funcName = ([System.Management.Automation.Language.FunctionDefinitionAst]$function).Name
-                        if ($funcName -eq $functionName) {
-                            return $param.Attributes.Extent.Text
-                        }
-                    }
-                }
+        $parseErrorTestCases += @{ moduleFileName = $moduleFile.Name; parseErrors = $parseErrors }
+
+        foreach($line in $schemaMofFileContent) {
+            if ($line -match "\s*(\[.*\b(Required|Key)\b.*\])\s*(.*) (.*);") {
+                $propertyType = $matches[2]
+                $propertyName = $matches[4].Replace("[]", "");
+                $mandatoryParamTestCases += @{ functionName = "Get-TargetResource"; astMembers = $astMembers; propertyName = $propertyName; moduleFileName = $moduleFile.Name; propertyType = $propertyType }
+                $mandatoryParamTestCases += @{ functionName = "Set-TargetResource"; astMembers = $astMembers; propertyName = $propertyName; moduleFileName = $moduleFile.Name; propertyType = $propertyType }
+                $mandatoryParamTestCases += @{ functionName = "Test-TargetResource"; astMembers = $astMembers; propertyName = $propertyName; moduleFileName = $moduleFile.Name; propertyType = $propertyType }
+            } elseif ($line -match "\s*(\[.*\])\s*(.*) (.*);") {
+                $propertyType = $matches[1]
+                $propertyName = $matches[3].Replace("[]", "");
+
+                $nonMandatoryParamTestCases += @{ functionName = "Get-TargetResource"; astMembers = $astMembers; propertyName = $propertyName; moduleFileName = $moduleFile.Name; propertyType = $propertyType }
+                $nonMandatoryParamTestCases += @{ functionName = "Set-TargetResource"; astMembers = $astMembers; propertyName = $propertyName; moduleFileName = $moduleFile.Name; propertyType = $propertyType }
+                $nonMandatoryParamTestCases += @{ functionName = "Test-TargetResource"; astMembers = $astMembers; propertyName = $propertyName; moduleFileName = $moduleFile.Name; propertyType = $propertyType }
             }
         }
+    }
 
-        function Test-ParameterIsMandatory($functionName, $astMembers, $propertyName, $moduleFile, $propertyType) {
-            $param = Get-ParameterFromFunction -functionName $functionName -astMembers $astMembers -propertyName $propertyName
-            It "Parameter '$propertyName' in function '$functionName' should be marked with [Parameter(Mandatory)] in $($moduleFile.Name) as its a $propertyType property" {
-                $param -contains "[Parameter(Mandatory)]" | should be $true
-            }
-        }
+    BeforeAll {
+        . (Join-Path -Path $script:scriptRoot -ChildPath "powershell-helpers.ps1")
+    }
 
-        function Test-ParameterIsNotMandatory($functionName, $astMembers, $propertyName, $moduleFile, $propertyType) {
-            $param = Get-ParameterFromFunction -functionName $functionName -astMembers $astMembers -propertyName $propertyName
-            It "Parameter '$propertyName' in function '$functionName' should not be marked with [Parameter(Mandatory)] in $($moduleFile.Name) as its not mandatory in the mof" {
-                $param -contains "[Parameter(Mandatory)]" | should be $false
-            }
-        }
+    It "The module <moduleFileName> should have no parse errors" -TestCases $parseErrorTestCases {
+        param($moduleFileName, $parseErrors)
+        $parseErrors | should -be $null
+    }
 
-        Describe "Module $($moduleFile.Name)" {
-            $tokens = $null;
-            $parseErrors = $null;
-            $ast = [System.Management.Automation.Language.Parser]::ParseFile($moduleFile.FullName, [ref] $tokens, [ref] $parseErrors);
-            $filter = { $true }
-            $astMembers = $ast.FindAll($filter, $true);
+    It "Parameter '<propertyName>' in function '<functionName>' should Be marked with [Parameter(Mandatory)] in <moduleFileName> as its a <propertyType> property" -TestCases $mandatoryParamTestCases {
+        param($functionName, $astMembers, $propertyName, $moduleFileName, $propertyType)
+        $param = Get-ParameterFromFunction -functionName $functionName -astMembers $astMembers -propertyName $propertyName
+        $param -contains "[Parameter(Mandatory)]" | Should -Be $true
+    }
 
-            It "The module $($moduleFile.Name) should have no parse errors" {
-                $parseErrors | should be $null
-            }
-
-            foreach($line in $schemaMofFileContent) {
-                if ($line -match "\s*(\[.*\b(Required|Key)\b.*\])\s*(.*) (.*);") {
-                    $propertyType = $matches[2]
-                    $propertyName = $matches[4].Replace("[]", "");
-
-                    Test-ParameterIsMandatory -functionName "Get-TargetResource" -astMembers $astMembers -propertyName $propertyName -moduleFile $moduleFile -propertyType $propertyType
-                    Test-ParameterIsMandatory -functionName "Set-TargetResource" -astMembers $astMembers -propertyName $propertyName -moduleFile $moduleFile -propertyType $propertyType
-                    Test-ParameterIsMandatory -functionName "Test-TargetResource" -astMembers $astMembers -propertyName $propertyName -moduleFile $moduleFile -propertyType $propertyType
-                } elseif ($line -match "\s*(\[.*\])\s*(.*) (.*);") {
-                    $propertyType = $matches[1]
-                    $propertyName = $matches[3].Replace("[]", "");
-                    Test-ParameterIsNotMandatory -functionName "Get-TargetResource" -astMembers $astMembers -propertyName $propertyName -moduleFile $moduleFile -propertyType $propertyType
-                    Test-ParameterIsNotMandatory -functionName "Set-TargetResource" -astMembers $astMembers -propertyName $propertyName -moduleFile $moduleFile -propertyType $propertyType
-                    Test-ParameterIsNotMandatory -functionName "Test-TargetResource" -astMembers $astMembers -propertyName $propertyName -moduleFile $moduleFile -propertyType $propertyType
-                }
-            }
-        }
+    It "Parameter <propertyName> in function <functionName> should not be marked with [Parameter(Mandatory)] in <moduleFileName? as its not mandatory in the mof" -TestCases $nonMandatoryParamTestCases {
+        param($functionName, $astMembers, $propertyName, $moduleFileName, $propertyType)
+        $param = Get-ParameterFromFunction -functionName $functionName -astMembers $astMembers -propertyName $propertyName
+        $param -contains "[Parameter(Mandatory)]" | Should -Be $false
     }
 }
 
 Describe "Test/Get/Set-TargetResource all implement the same properties" {
     $path = Resolve-Path "$PSCommandPath/../../OctopusDSC/DSCResources"
     $schemaMofFiles = Get-ChildItem $path -Recurse -Filter *.schema.mof
+    $cases = @()
     foreach ($schemaMofFile in $schemaMofFiles) {
         $schemaMofFileContent = Get-Content $schemaMofFile.FullName
         $moduleFile = Get-Item ($schemaMofFile.FullName -replace ".schema.mof", ".psm1")
 
-        function Get-ParameterFromFunction($functionName, $astMembers, $propertyName) {
-            foreach($param in $astMembers) {
-                if ($null -ne $param.name -and $param.Name.ToString() -eq "`$$propertyName") {
-                    $function = $param.Parent.Parent.Parent
-                    if ($function -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
-                        $funcName = ([System.Management.Automation.Language.FunctionDefinitionAst]$function).Name
-                        if ($funcName -eq $functionName) {
-                            return $param
-                        }
-                    }
-                }
+        $tokens = $null;
+        $parseErrors = $null;
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($moduleFile.FullName, [ref] $tokens, [ref] $parseErrors);
+        $filter = { $true }
+        $astMembers = $ast.FindAll($filter, $true);
+        foreach($line in $schemaMofFileContent) {
+            if ($line -match "\s*(\[.*\])\s*(.*) (.*);") {
+                $propertyName = $matches[3].Replace("[]", "");
+                $cases += @{ functionName = "Get-TargetResource"; astMembers = $astMembers; propertyName = $propertyName; moduleFileName = $moduleFile.Name; }
+                $cases += @{ functionName = "Set-TargetResource"; astMembers = $astMembers; propertyName = $propertyName; moduleFileName = $moduleFile.Name; }
+                $cases += @{ functionName = "Test-TargetResource"; astMembers = $astMembers; propertyName = $propertyName; moduleFileName = $moduleFile.Name; }
             }
         }
+    }
 
-        function Test-Parameter($functionName, $astMembers, $propertyName, $moduleFile, $propertyType) {
-            $param = Get-ParameterFromFunction -functionName $functionName -astMembers $astMembers -propertyName $propertyName
-            It "Function '$functionName' should have parameter '$propertyName' in $($moduleFile.Name) as its a defined in the .schema.mof file" {
-                $param | should not be $null
-            }
-        }
+    BeforeAll {
+        . (Join-Path -Path $script:scriptRoot -ChildPath "powershell-helpers.ps1")
+    }
 
-        Describe "Module $($moduleFile.Name)" {
-            $tokens = $null;
-            $parseErrors = $null;
-            $ast = [System.Management.Automation.Language.Parser]::ParseFile($moduleFile.FullName, [ref] $tokens, [ref] $parseErrors);
-            $filter = { $true }
-            $astMembers = $ast.FindAll($filter, $true);
-
-            foreach($line in $schemaMofFileContent) {
-                if ($line -match "\s*(\[.*\])\s*(.*) (.*);") {
-                    $propertyType = $matches[1]
-                    $propertyName = $matches[3].Replace("[]", "");
-
-                    Test-Parameter -functionName "Get-TargetResource" -astMembers $astMembers -propertyName $propertyName -moduleFile $moduleFile -propertyType $propertyType
-                    Test-Parameter -functionName "Set-TargetResource" -astMembers $astMembers -propertyName $propertyName -moduleFile $moduleFile -propertyType $propertyType
-                    Test-Parameter -functionName "Test-TargetResource" -astMembers $astMembers -propertyName $propertyName -moduleFile $moduleFile -propertyType $propertyType
-                }
-            }
-        }
+    It "Function <functionName> should have parameter <propertyName> in <moduleFileName> as its a defined in the .schema.mof file" -TestCases $cases {
+        param($functionName, $astMembers, $propertyName, $moduleFileName)
+        $param = Get-ParameterFromFunction -functionName $functionName -astMembers $astMembers -propertyName $propertyName
+        $param | Should -not -be $null
     }
 }
 
 Describe "Configuration Scenarios" {
     $path = Resolve-Path "$PSCommandPath/../../Tests/Scenarios"
-    $configurationFiles = Get-ChildItem $path -Recurse -Filter *.ps1
-    foreach ($configurationFile in $configurationFiles) {
-        $confName = [System.Io.Path]::GetFileNameWithoutExtension($configurationFile.Name)
+    $name = @{label="name";expression={[System.Io.Path]::GetFileNameWithoutExtension($_.Name)}};
+    $fullName = @{label="fullName";expression={$_.FullName}};
+    . (Join-Path -Path $script:scriptRoot -ChildPath "powershell-helpers.ps1")
 
-        It "Configuration block in scenario $($configurationFile.Name) should have the same name as the file" {
-            $configurationFile.FullName | Should -FileContentMatch "Configuration $confName"
-        }
+    $cases = @(Get-ChildItem $path -Recurse -Filter *.ps1 | Select-Object -Property $name, $fullName) | ConvertTo-Hashtable
 
-        It "Scenario $($configurationFile.Name) should have a matching spec" {
-            $specName = $configurationFile.Name.Replace('.ps1', '_spec.rb').ToLower()
-            (Resolve-Path "$PSCommandPath/../../Tests/Spec/$specName") | Should -Exist
-        }
+    It "Configuration block in scenario <name> should have the same name as the file" -TestCases $cases {
+        param([string]$name, [string]$fullName)
+        $fullName | Should -FileContentMatch "Configuration $name"
+    }
+
+    It "Scenario <name> should have a matching spec" -TestCases $cases {
+        param([string]$name, [string]$fullName)
+        $specName = ($name + '_spec.rb').ToLower()
+        (Resolve-Path "$PSCommandPath/../../Tests/Spec/$specName") | Should -Exist
     }
 }

--- a/Tests/OctopusDSC.Tests.ps1
+++ b/Tests/OctopusDSC.Tests.ps1
@@ -175,6 +175,17 @@ Describe "Mandatory Parameters" {
 }
 
 Describe "Test/Get/Set-TargetResource all implement the same properties" {
+    function Get-TestCase($functionName, $astMembers, $propertyName, $moduleFileName, $propertyType) {
+        $param = Get-ParameterFromFunction -functionName $functionName -astMembers $astMembers -propertyName $propertyName
+        $paramExists = $null -ne $param
+        return @{
+            functionName = $functionName;
+            propertyName = $propertyName;
+            moduleFileName = $moduleFile.Name;
+            paramExists = $paramExists
+        }
+    }
+
     $path = Resolve-Path "$PSCommandPath/../../OctopusDSC/DSCResources"
     $schemaMofFiles = Get-ChildItem $path -Recurse -Filter *.schema.mof
     $cases = @()
@@ -190,9 +201,9 @@ Describe "Test/Get/Set-TargetResource all implement the same properties" {
         foreach($line in $schemaMofFileContent) {
             if ($line -match "\s*(\[.*\])\s*(.*) (.*);") {
                 $propertyName = $matches[3].Replace("[]", "");
-                $cases += @{ functionName = "Get-TargetResource"; astMembers = $astMembers; propertyName = $propertyName; moduleFileName = $moduleFile.Name; }
-                $cases += @{ functionName = "Set-TargetResource"; astMembers = $astMembers; propertyName = $propertyName; moduleFileName = $moduleFile.Name; }
-                $cases += @{ functionName = "Test-TargetResource"; astMembers = $astMembers; propertyName = $propertyName; moduleFileName = $moduleFile.Name; }
+                $cases += Get-TestCase "Get-TargetResource" $astMembers $propertyName $moduleFile.Name
+                $cases += Get-TestCase "Set-TargetResource" $astMembers $propertyName $moduleFile.Name
+                $cases += Get-TestCase "Test-TargetResource" $astMembers $propertyName $moduleFile.Name
             }
         }
     }
@@ -202,9 +213,8 @@ Describe "Test/Get/Set-TargetResource all implement the same properties" {
     }
 
     It "Function <functionName> should have parameter <propertyName> in <moduleFileName> as its a defined in the .schema.mof file" -TestCases $cases {
-        param($functionName, $astMembers, $propertyName, $moduleFileName)
-        $param = Get-ParameterFromFunction -functionName $functionName -astMembers $astMembers -propertyName $propertyName
-        $param | Should -not -be $null
+        param($functionName, $propertyName, $moduleFileName, $paramExists)
+        $paramExists | Should -be $true
     }
 }
 

--- a/Tests/OctopusDSC.Tests.ps1
+++ b/Tests/OctopusDSC.Tests.ps1
@@ -168,7 +168,7 @@ Describe "Mandatory Parameters" {
         $paramisMandatory | Should -Be $true
     }
 
-    It "Parameter <propertyName> in function <functionName> should not be marked with [Parameter(Mandatory)] in <moduleFileName? as its not mandatory in the mof" -TestCases $nonMandatoryParamTestCases {
+    It "Parameter <propertyName> in function <functionName> should not be marked with [Parameter(Mandatory)] in <moduleFileName> as its not mandatory in the mof" -TestCases $nonMandatoryParamTestCases {
         param($functionName, $propertyName, $moduleFileName, $propertyType, $paramisMandatory)
         $paramisMandatory | Should -Be $false
     }

--- a/Tests/Scenarios/Server_Scenario_08_Upgrade.ps1
+++ b/Tests/Scenarios/Server_Scenario_08_Upgrade.ps1
@@ -1,7 +1,5 @@
 Configuration Server_Scenario_08_Upgrade
 {
-    param ($ApiKey)
-
     Import-DscResource -ModuleName OctopusDSC
     Import-DscResource -ModuleName PSDesiredStateConfiguration
 

--- a/build-aws.ps1
+++ b/build-aws.ps1
@@ -54,6 +54,7 @@ if(-not $SkipPester) {
   $configuration.Run.PassThru = $true
   $configuration.Run.Exit = $true
   $result = Invoke-Pester -configuration $configuration
+  write-output "##teamcity[publishArtifacts 'PesterTestResults.xml']"
   if ($result.FailedCount -gt 0) {
     exit 1
   }

--- a/build-aws.ps1
+++ b/build-aws.ps1
@@ -53,7 +53,6 @@ if(-not $SkipPester) {
   $configuration.TestResult.OutputFormat = 'NUnitXml'
   $configuration.Run.PassThru = $true
   $configuration.Run.Exit = $true
-  $configuration.Output.Verbosity = 'Detailed'
   $result = Invoke-Pester -configuration $configuration
   if ($result.FailedCount -gt 0) {
     exit 1

--- a/build-aws.ps1
+++ b/build-aws.ps1
@@ -43,10 +43,15 @@ Remove-OldLogsBeforeNewRun
 if(-not $SkipPester) {
   Write-Output "##teamcity[blockOpened name='Pester tests']"
   Write-Output "Importing Pester module"
-  Import-PowerShellModule -Name "Pester" -MinimumVersion "4.9.0"
+  Import-PowerShellModule -Name "Pester" -MinimumVersion "5.0.2"
 
   Write-Output "Running Pester Tests"
-  $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
+  $configuration = [PesterConfiguration]::Default
+  $configuration.TestResult.OutputPath = 'PesterTestResults.xml'
+  $configuration.TestResult.OutputFormat = 'NUnitXml'
+  $configuration.Run.PassThru = $true
+  $configuration.Output = 'Detailed'
+  $result = Invoke-Pester -configuration $configuration
   if ($result.FailedCount -gt 0) {
     exit 1
   }

--- a/build-aws.ps1
+++ b/build-aws.ps1
@@ -48,6 +48,7 @@ if(-not $SkipPester) {
 
   Write-Output "Running Pester Tests"
   $configuration = [PesterConfiguration]::Default
+  $configuration.TestResult.Enabled = $true
   $configuration.TestResult.OutputPath = 'PesterTestResults.xml'
   $configuration.TestResult.OutputFormat = 'NUnitXml'
   $configuration.Run.PassThru = $true

--- a/build-aws.ps1
+++ b/build-aws.ps1
@@ -44,6 +44,7 @@ if(-not $SkipPester) {
   Write-Output "##teamcity[blockOpened name='Pester tests']"
   Write-Output "Importing Pester module"
   Import-PowerShellModule -Name "Pester" -MinimumVersion "5.0.2"
+  Import-PowerShellModule -Name "PSScriptAnalyzer" -MinimumVersion "1.19.0"
 
   Write-Output "Running Pester Tests"
   $configuration = [PesterConfiguration]::Default

--- a/build-aws.ps1
+++ b/build-aws.ps1
@@ -50,7 +50,8 @@ if(-not $SkipPester) {
   $configuration.TestResult.OutputPath = 'PesterTestResults.xml'
   $configuration.TestResult.OutputFormat = 'NUnitXml'
   $configuration.Run.PassThru = $true
-  $configuration.Output = 'Detailed'
+  $configuration.Run.Exit = $true
+  $configuration.Output.Verbosity = 'Detailed'
   $result = Invoke-Pester -configuration $configuration
   if ($result.FailedCount -gt 0) {
     exit 1

--- a/build-azure.ps1
+++ b/build-azure.ps1
@@ -49,6 +49,8 @@ if(-not $SkipPester) {
     $configuration.TestResult.OutputPath = 'PesterTestResults.xml'
     $configuration.TestResult.OutputFormat = 'NUnitXml'
     $configuration.Run.PassThru = $true
+    $configuration.Run.Exit = $true
+    $configuration.Output.Verbosity = 'Detailed'
     $result = Invoke-Pester -configuration $configuration
     if ($result.FailedCount -gt 0) {
       exit 1

--- a/build-azure.ps1
+++ b/build-azure.ps1
@@ -43,6 +43,7 @@ Remove-OldLogsBeforeNewRun
 if(-not $SkipPester) {
     Write-Output "Importing Pester module"
     Import-PowerShellModule -Name "Pester" -MinimumVersion "5.0.2"
+    Import-PowerShellModule -Name "PSScriptAnalyzer" -MinimumVersion "1.19.0"
 
     Write-Output "Running Pester Tests"
     $configuration = [PesterConfiguration]::Default

--- a/build-azure.ps1
+++ b/build-azure.ps1
@@ -42,10 +42,14 @@ Remove-OldLogsBeforeNewRun
 
 if(-not $SkipPester) {
     Write-Output "Importing Pester module"
-    Import-PowerShellModule -Name "Pester" -MinimumVersion "4.9.0"
+    Import-PowerShellModule -Name "Pester" -MinimumVersion "5.0.2"
 
     Write-Output "Running Pester Tests"
-    $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
+    $configuration = [PesterConfiguration]::Default
+    $configuration.TestResult.OutputPath = 'PesterTestResults.xml'
+    $configuration.TestResult.OutputFormat = 'NUnitXml'
+    $configuration.Run.PassThru = $true
+    $result = Invoke-Pester -configuration $configuration
     if ($result.FailedCount -gt 0) {
       exit 1
     }

--- a/build-azure.ps1
+++ b/build-azure.ps1
@@ -47,6 +47,7 @@ if(-not $SkipPester) {
 
     Write-Output "Running Pester Tests"
     $configuration = [PesterConfiguration]::Default
+    $configuration.TestResult.Enabled = $true
     $configuration.TestResult.OutputPath = 'PesterTestResults.xml'
     $configuration.TestResult.OutputFormat = 'NUnitXml'
     $configuration.Run.PassThru = $true

--- a/build-hyperv.ps1
+++ b/build-hyperv.ps1
@@ -57,6 +57,7 @@ Remove-OldLogsBeforeNewRun
 
 if(-not $SkipPester) {
   Import-PowerShellModule -Name "Pester" -MinimumVersion "5.0.2"
+  Import-PowerShellModule -Name "PSScriptAnalyzer" -MinimumVersion "1.19.0"
   Write-Output "Running Pester Tests"
 
   $configuration = [PesterConfiguration]::Default

--- a/build-hyperv.ps1
+++ b/build-hyperv.ps1
@@ -56,10 +56,15 @@ Test-PluginInstalled "vagrant-winrm-file-download"
 Remove-OldLogsBeforeNewRun
 
 if(-not $SkipPester) {
-  Import-PowerShellModule -Name "Pester" -MinimumVersion "4.9.0"
+  Import-PowerShellModule -Name "Pester" -MinimumVersion "5.0.2"
   Write-Output "Running Pester Tests"
 
-  $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
+  $configuration = [PesterConfiguration]::Default
+  $configuration.TestResult.OutputPath = 'PesterTestResults.xml'
+  $configuration.TestResult.OutputFormat = 'NUnitXml'
+  $configuration.Run.PassThru = $true
+  $result = Invoke-Pester -configuration $configuration
+
   if ($result.FailedCount -gt 0) {
     exit 1
   }

--- a/build-hyperv.ps1
+++ b/build-hyperv.ps1
@@ -63,6 +63,8 @@ if(-not $SkipPester) {
   $configuration.TestResult.OutputPath = 'PesterTestResults.xml'
   $configuration.TestResult.OutputFormat = 'NUnitXml'
   $configuration.Run.PassThru = $true
+  $configuration.Run.Exit = $true
+  $configuration.Output.Verbosity = 'Detailed'
   $result = Invoke-Pester -configuration $configuration
 
   if ($result.FailedCount -gt 0) {

--- a/build-hyperv.ps1
+++ b/build-hyperv.ps1
@@ -61,6 +61,7 @@ if(-not $SkipPester) {
   Write-Output "Running Pester Tests"
 
   $configuration = [PesterConfiguration]::Default
+  $configuration.TestResult.Enabled = $true
   $configuration.TestResult.OutputPath = 'PesterTestResults.xml'
   $configuration.TestResult.OutputFormat = 'NUnitXml'
   $configuration.Run.PassThru = $true

--- a/build-virtualbox.ps1
+++ b/build-virtualbox.ps1
@@ -39,6 +39,7 @@ if(-not $SkipPester) {
 
   Write-Output "Running Pester Tests"
   $configuration = [PesterConfiguration]::Default
+  $configuration.TestResult.Enabled = $true
   $configuration.TestResult.OutputPath = 'PesterTestResults.xml'
   $configuration.TestResult.OutputFormat = 'NUnitXml'
   $configuration.Run.PassThru = $true

--- a/build-virtualbox.ps1
+++ b/build-virtualbox.ps1
@@ -35,6 +35,7 @@ Remove-OldLogsBeforeNewRun
 if(-not $SkipPester) {
   Write-Output "Importing Pester module"
   Import-PowerShellModule -Name "Pester" -MinimumVersion "5.0.2"
+  Import-PowerShellModule -Name "PSScriptAnalyzer" -MinimumVersion "1.19.0"
 
   Write-Output "Running Pester Tests"
   $configuration = [PesterConfiguration]::Default

--- a/build-virtualbox.ps1
+++ b/build-virtualbox.ps1
@@ -41,6 +41,7 @@ if(-not $SkipPester) {
   $configuration.TestResult.OutputPath = 'PesterTestResults.xml'
   $configuration.TestResult.OutputFormat = 'NUnitXml'
   $configuration.Run.PassThru = $true
+  $configuration.Run.Exit = $true
   $configuration.Output.Verbosity = 'Detailed'
   $result = Invoke-Pester -configuration $configuration
   if ($result.FailedCount -gt 0) {

--- a/build-virtualbox.ps1
+++ b/build-virtualbox.ps1
@@ -34,10 +34,15 @@ Remove-OldLogsBeforeNewRun
 
 if(-not $SkipPester) {
   Write-Output "Importing Pester module"
-  Import-PowerShellModule -Name "Pester" -MinimumVersion "4.9.0"
+  Import-PowerShellModule -Name "Pester" -MinimumVersion "5.0.2"
 
   Write-Output "Running Pester Tests"
-  $result = Invoke-Pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -PassThru
+  $configuration = [PesterConfiguration]::Default
+  $configuration.TestResult.OutputPath = 'PesterTestResults.xml'
+  $configuration.TestResult.OutputFormat = 'NUnitXml'
+  $configuration.Run.PassThru = $true
+  $configuration.Output.Verbosity = 'Detailed'
+  $result = Invoke-Pester -configuration $configuration
   if ($result.FailedCount -gt 0) {
     exit 1
   }


### PR DESCRIPTION
Our build agents auto-upgraded to Pester 5.0.2...

There's [a lot of breaking changes](https://github.com/pester/Pester#breaking-changes) between 4.x, and 5.
