### PR TITLE
Ensure that we use correct types in return from Get-TargetResource

### DIFF
--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
@@ -105,6 +105,7 @@ function Get-TargetResource {
         $existingAutoLoginEnabled = $null
         $existingOctopusServiceCredential = [PSCredential]::Empty
         $existingOctopusBuiltInWorkerCredential = [PSCredential]::Empty
+        $existingOctopusMasterKey = [PSCredential]::Empty
         $existingHomeDirectory = $null
         $existingPackagesDirectory = $null
         $existingArtifactsDirectory = $null
@@ -181,34 +182,34 @@ function Get-TargetResource {
         }
 
         $currentResource = @{
-            Name                                      = $Name;
-            Ensure                                    = $existingEnsure;
-            State                                     = $existingState;
-            DownloadUrl                               = $existingDownloadUrl;
-            WebListenPrefix                           = $existingWebListenPrefix;
-            SqlDbConnectionString                     = $existingSqlDbConnectionString;
-            ForceSSL                                  = $existingForceSSL;
-            HSTSEnabled                               = $existingHSTSEnabled;
-            HSTSMaxAge                                = $existingHSTSMaxAge;
-            AllowUpgradeCheck                         = $existingOctopusUpgradesAllowChecking;
-            AllowCollectionOfUsageStatistics          = $existingOctopusUpgradesIncludeStatistics;
-            ListenPort                                = $existingListenPort;
-            OctopusAdminCredential                    = $existingOctopusAdminCredential;
-            LegacyWebAuthenticationMode               = $existingLegacyWebAuthenticationMode;
-            AutoLoginEnabled                          = $existingAutoLoginEnabled;
-            OctopusServiceCredential                  = $existingOctopusServiceCredential;
-            HomeDirectory                             = $existingHomeDirectory;
-            LicenseKey                                = $existingLicenseKey;
-            OctopusBuiltInWorkerCredential            = $existingOctopusBuiltInWorkerCredential;
-            PackagesDirectory                         = $existingPackagesDirectory;
-            ArtifactsDirectory                        = $existingArtifactsDirectory;
-            TaskLogsDirectory                         = $existingTaskLogsDirectory;
-            LogTaskMetrics                            = $existingLogTaskMetrics;
-            LogRequestMetrics                         = $existingLogRequestMetrics;
-            TaskCap                                   = $existingTaskCap;
-            OctopusMasterKey                          = $existingOctopusMasterKey;
-            GrantDatabasePermissions                  = $GrantDatabasePermissions;
-            SkipLicenseCheck                          = $SkipLicenseCheck;
+            Name                                      = [string]$Name;
+            Ensure                                    = [string]$existingEnsure;
+            State                                     = [string]$existingState;
+            DownloadUrl                               = [string]$existingDownloadUrl;
+            WebListenPrefix                           = [string]$existingWebListenPrefix;
+            SqlDbConnectionString                     = [string]$existingSqlDbConnectionString;
+            ForceSSL                                  = [boolean]$existingForceSSL;
+            HSTSEnabled                               = [boolean]$existingHSTSEnabled;
+            HSTSMaxAge                                = [uint64]$existingHSTSMaxAge;
+            AllowUpgradeCheck                         = [boolean]$existingOctopusUpgradesAllowChecking;
+            AllowCollectionOfUsageStatistics          = [boolean]$existingOctopusUpgradesIncludeStatistics;
+            ListenPort                                = [uint16]$existingListenPort;
+            OctopusAdminCredential                    = [PSCredential]$existingOctopusAdminCredential;
+            LegacyWebAuthenticationMode               = [string]$existingLegacyWebAuthenticationMode;
+            AutoLoginEnabled                          = [boolean]$existingAutoLoginEnabled;
+            OctopusServiceCredential                  = [PSCredential]$existingOctopusServiceCredential;
+            HomeDirectory                             = [string]$existingHomeDirectory;
+            LicenseKey                                = [string]$existingLicenseKey;
+            OctopusBuiltInWorkerCredential            = [PSCredential]$existingOctopusBuiltInWorkerCredential;
+            PackagesDirectory                         = [string]$existingPackagesDirectory;
+            ArtifactsDirectory                        = [string]$existingArtifactsDirectory;
+            TaskLogsDirectory                         = [string]$existingTaskLogsDirectory;
+            LogTaskMetrics                            = [boolean]$existingLogTaskMetrics;
+            LogRequestMetrics                         = [boolean]$existingLogRequestMetrics;
+            TaskCap                                   = [uint64]$existingTaskCap;
+            OctopusMasterKey                          = [PSCredential]$existingOctopusMasterKey;
+            GrantDatabasePermissions                  = [boolean]$GrantDatabasePermissions;
+            SkipLicenseCheck                          = [boolean]$SkipLicenseCheck;
         }
 
         return $currentResource

--- a/OctopusDSC/OctopusDSCHelpers.ps1
+++ b/OctopusDSC/OctopusDSCHelpers.ps1
@@ -266,8 +266,11 @@ function Get-ServerConfiguration($instanceName) {
         }
     } -MaxRetries 3 -IntervalInMilliseconds 100
 
-    $masterkey = & $octopusServerExePath show-master-key --noconsolelogging --console --instance $instanceName
-    $config | Add-Member -NotePropertyName "OctopusMasterKey" -NotePropertyValue $masterkey
+    $plainTextMasterKey = & $octopusServerExePath show-master-key --noconsolelogging --console --instance $instanceName
+
+    $encryptedMasterKey = New-Object SecureString
+    $plainTextMasterKey.ToCharArray() | Foreach-Object { $encryptedMasterKey.AppendChar($_) }
+    $config | Add-Member -NotePropertyName "OctopusMasterKey" -NotePropertyValue (New-Object System.Management.Automation.PSCredential ("ignored", $encryptedMasterKey))
 
     return $config
 }


### PR DESCRIPTION
We thought we'd fix the issue when the masterkey was triggering a restart, but we missed a bit (even though I wrote lots of tests 🤦‍♂️).

Added some more tests to confirm its the right type as well.


Customer reported:

>  Unfortunately, there is still a need to make a tiny adjustment. The function Get-ServerConfiguration on the OctopusDSCHelpers.ps1 file adds the 'OctopusMasterKey' property as a plain password text into the $config object. Nevertheless, this property is expected to be a PSCredential.
> 
> Therefore, line 270 ...
> 
```
$config | Add-Member -NotePropertyName "OctopusMasterKey" -NotePropertyValue $masterkey
```
> ... should be replaced by something like ...
>
```
$masterkeycred = New-Object System.Management.Automation.PSCredential ("notused", ($masterkey | ConvertTo-SecureString -AsPlainText -Force))
$config | Add-Member -NotePropertyName "OctopusMasterKey" -NotePropertyValue $masterkeycred
```

Fixes https://github.com/OctopusDeploy/OctopusDSC/issues/258