### PR TITLE
Add DHCP publicHostNameConfiguration.

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -763,6 +763,10 @@ function Get-MyPrivateIPAddress {
         [string]$cidrRange
         )
     {
+    
+        # http://www.padisetty.com/2014/05/powershell-bit-manipulation-and-network.html
+        # The original code is available here - https://github.com/padisetty/Samples under Apache 2
+        # Initially found this via http://www.gi-architects.co.uk/2016/02/powershell-check-if-ip-or-subnet-matchesfits/
         function CheckNetworkToSubnet ([uint32]$un2, [uint32]$ma2, [uint32]$un1)
         {
             return ($un2 -eq ($ma2 -band $un1))
@@ -783,7 +787,7 @@ function Get-MyPrivateIPAddress {
             # IPv6 is not currently supported
             return $False
         }
-        # Separate the network address and lenght
+        # Separate the network address and length
         $network1, [int]$subnetlen1 = $ipAddress.Split('/')
         $network2, [int]$subnetlen2 = $cidrRange.Split('/')
     

--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.schema.mof
@@ -4,7 +4,6 @@ class cTentacleAgent : OMI_BaseResource
   [Key] string Name;
   [Write, ValueMap{"Present", "Absent"}, Values{"Present", "Absent"}] string Ensure;
   [Write, ValueMap{"Started", "Stopped"}, Values{"Started", "Stopped"}] string State;
-
   [Write, ValueMap{"Listen", "Poll"}, Values{"Listen", "Poll"}] string CommunicationMode;
   [Write] string ApiKey;
   [Write] string OctopusServerUrl;
@@ -20,8 +19,9 @@ class cTentacleAgent : OMI_BaseResource
   [Write] string DefaultApplicationDirectory;
   [Write] string TentacleDownloadUrl;
   [Write] string TentacleDownloadUrl64;
-  [Write, ValueMap{"PublicIp", "FQDN", "ComputerName", "Custom"}, Values{"PublicIp", "FQDN", "ComputerName", "Custom"}] string PublicHostNameConfiguration;
+  [Write, ValueMap{"PublicIp", "FQDN", "ComputerName", "DHCP", "Custom"}, Values{"PublicIp", "FQDN", "ComputerName", "DHCP", "Custom"}] string PublicHostNameConfiguration;
   [Write] string CustomPublicHostName;
+  [Write] string CidrRange;
   [Write] string TentacleHomeDirectory;
   [Write] Boolean RegisterWithServer;
   [Write] String OctopusServerThumbprint;


### PR DESCRIPTION
This detects an IP address that's on the host based on a CIDR range, passed in as the CidrRange parameter.

Discovering the IP this way allows for deployments to non-domain-joined
  deployment targets to not require public IP addresses.


I'm unsure on tests at this time, there isn't documentation on how to run the tests.