### PR TITLE
Try and workaround mitchellh/vagrant-aws#566

### DIFF
--- a/vagrantfile
+++ b/vagrantfile
@@ -2,6 +2,19 @@
 
 VAGRANT_FILE_API_VERSION = "2"
 
+# start workaround for https://github.com/mitchellh/vagrant-aws/issues/566
+class Hash
+  def slice(*keep_keys)
+    h = {}
+    keep_keys.each { |key| h[key] = fetch(key) if has_key?(key) }
+    h
+  end unless Hash.method_defined?(:slice)
+  def except(*less_keys)
+    slice(*keys - less_keys)
+  end unless Hash.method_defined?(:except)
+end
+# end workaround for https://github.com/mitchellh/vagrant-aws/issues/566
+
 aws_access_key_id = ENV['AWS_ACCESS_KEY_ID'] || 'not-set'
 aws_secret_access_key = ENV['AWS_SECRET_ACCESS_KEY'] || 'not-set'
 aws_subnet_id = ENV['AWS_SUBNET_ID'] || 'not-set'


### PR DESCRIPTION
Upgrading vagrant to 2.2.14, triggered an error:

```
  Running Vagrant with arguments 'up --provider aws'
  WARNING: StdErr:
  WARNING: /home/agentuser/.vagrant.d/gems/2.6.6/gems/vagrant-aws-0.7.2/lib/vagrant-aws/action/connect_aws.rb:41:in `call': undefined method `except' for #<Hash:0x00000000038eda98> (NoMethodError)
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/action/warden.rb:48:in `call'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/action/warden.rb:48:in `call'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/action/builder.rb:149:in `call'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/action/runner.rb:89:in `block in run'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/util/busy.rb:19:in `busy'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/action/runner.rb:89:in `run'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/machine.rb:246:in `action_raw'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/machine.rb:215:in `block in action'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/machine.rb:197:in `block in action'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/machine.rb:201:in `action'
  WARNING:   from /home/agentuser/.vagrant.d/gems/2.6.6/gems/vagrant-aws-0.7.2/lib/vagrant-aws/provider.rb:32:in `state'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/machine.rb:541:in `state'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/machine.rb:154:in `initialize'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/vagrantfile.rb:81:in `new'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/vagrantfile.rb:81:in `machine'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/environment.rb:715:in `machine'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/plugin/v2/command.rb:180:in `block in with_target_vms'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/plugin/v2/command.rb:204:in `block in with_target_vms'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/plugin/v2/command.rb:186:in `each'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/plugin/v2/command.rb:186:in `with_target_vms'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/plugins/commands/up/command.rb:87:in `execute'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/cli.rb:67:in `execute'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/lib/vagrant/environment.rb:290:in `cli'
  WARNING:   from /opt/vagrant/embedded/gems/2.2.14/gems/vagrant-2.2.14/bin/vagrant:205:in `<main>
```

This PR implements the suggested fix from https://github.com/mitchellh/vagrant-aws/issues/566#issuecomment-580812210