### PR TITLE
Added policy to register worker sections

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -1171,8 +1171,7 @@ function Add-TentacleToWorkerPool {
             )
         }
 
-        if(![string]::IsNullOrWhiteSpace($Policy))
-        {
+        if(![string]::IsNullOrWhiteSpace($Policy)) {
             $argumentList += @(
                 "--policy", "$Policy"
             )

--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -520,7 +520,8 @@ function Set-TargetResource {
                 -customPublicHostName $customPublicHostName `
                 -listenPort $listenPort `
                 -tentacleCommsPort $tentacleCommsPort `
-                -space $space
+                -space $space `
+                -Policy $Policy
         } elseif (![string]::IsNullOrEmpty($Environments) -and ![string]::IsNullOrEmpty($Roles)) {
              Register-Tentacle -name $Name `
                  -apiKey $ApiKey `
@@ -958,7 +959,8 @@ function New-Tentacle {
                 -publicHostNameConfiguration $publicHostNameConfiguration `
                 -listenPort $listenPort `
                 -tentacleCommsPort $tentacleCommsPort `
-                -space $space
+                -space $space `
+                -Policy $Policy
         } elseif (![string]::IsNullOrEmpty($Environments) -and ![string]::IsNullOrEmpty($Roles)) {
             Write-Verbose "Registering Tentacle"
             Register-Tentacle -name $name `
@@ -1116,7 +1118,12 @@ function Add-TentacleToWorkerPool {
         [AllowNull()]
         [AllowEmptyString()]
         [String]
-        $Space
+        $Space,
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [String]
+        $Policy
     )
     if ($listenPort -eq 0) {
         $listenPort = 10933
@@ -1161,6 +1168,13 @@ function Add-TentacleToWorkerPool {
             $argumentList += @(
                 "--comms-style", "TentacleActive",
                 "--server-comms-port", $serverPort
+            )
+        }
+
+        if(![string]::IsNullOrWhiteSpace($Policy))
+        {
+            $argumentList += @(
+                "--policy", $Policy
             )
         }
 

--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -1174,7 +1174,7 @@ function Add-TentacleToWorkerPool {
         if(![string]::IsNullOrWhiteSpace($Policy))
         {
             $argumentList += @(
-                "--policy", $Policy
+                "--policy", "$Policy"
             )
         }
 

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/NewWorker/ExpectedResult.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/NewWorker/ExpectedResult.ps1
@@ -3,5 +3,5 @@ return @(
     "new-certificate --instance Tentacle --console",
     "configure --instance Tentacle --home C:\Octopus --app C:\Applications --console --port 10935",
     "service --install --instance Tentacle --console --reconfigure --username Admin --password S3cur3P4ssphraseHere!",
-    "register-worker --instance Tentacle --server http://localhost:81 --name My Worker --force --apiKey API-1234 --comms-style TentaclePassive --publicHostName mytestserver.local --workerpool NodeJSWorker"
+    "register-worker --instance Tentacle --server http://localhost:81 --name My Worker --force --apiKey API-1234 --comms-style TentaclePassive --publicHostName mytestserver.local --policy My machine policy --workerpool NodeJSWorker"
 )

--- a/OctopusDSC/Tests/TentacleExeInvocationFiles/NewWorker/RequestedState.ps1
+++ b/OctopusDSC/Tests/TentacleExeInvocationFiles/NewWorker/RequestedState.ps1
@@ -19,4 +19,5 @@ return @{
     DefaultApplicationDirectory = "C:\Applications"
     TentacleHomeDirectory = "C:\Octopus"
     WorkerPools = @("NodeJSWorker")
+    Policy = "My machine policy"
 }

--- a/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
@@ -475,7 +475,7 @@ try
 
             Context "New Worker" {
                 BeforeAll {
-                    Mock Invoke-TentacleCommand  #{ write-host "`"$($cmdArgs -join ' ')`"," }
+                    Mock Invoke-TentacleCommand # { write-host "`"$($cmdArgs -join ' ')`"," }
                     Mock Get-TargetResource { return Get-CurrentConfiguration "NewWorker" }
                     Mock Invoke-MsiExec {}
                     Mock Request-File {}

--- a/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleAgent.Tests.ps1
@@ -475,7 +475,7 @@ try
 
             Context "New Worker" {
                 BeforeAll {
-                    Mock Invoke-TentacleCommand # { write-host "`"$($cmdArgs -join ' ')`"," }
+                    Mock Invoke-TentacleCommand  #{ write-host "`"$($cmdArgs -join ' ')`"," }
                     Mock Get-TargetResource { return Get-CurrentConfiguration "NewWorker" }
                     Mock Invoke-MsiExec {}
                     Mock Request-File {}


### PR DESCRIPTION
https://octopus.zendesk.com/agent/tickets/67066 - customer reported that using DSC with workers does not set the correct Machine Policy.  Reviewed code and found that Policy was not being passed as a parameter to register-worker command.  Added Policy so that the correct policy is set when using DSC.