### PR TITLE
Log the actual exe we are calling

### DIFF
--- a/OctopusDSC/OctopusDSCHelpers.ps1
+++ b/OctopusDSC/OctopusDSCHelpers.ps1
@@ -171,16 +171,16 @@ function Get-MaskedOutput {
     return $arguments
 }
 
-function Write-VerboseWithMaskedCommand ($cmdArgs) {
+function Write-VerboseWithMaskedCommand ($exePath, $cmdArgs) {
     $copiedarguments = @() # hack to pass a copy of the array, not a reference
     $copiedarguments += $cmdArgs
     $maskedarguments = Get-MaskedOutput $copiedarguments
-    Write-Verbose "Executing command '$octopusServerExePath $($maskedarguments -join ' ')'"
+    Write-Verbose "Executing command '$exePath $($maskedarguments -join ' ')'"
 }
 
 function Invoke-OctopusServerCommand ($cmdArgs) {
 
-    Write-VerboseWithMaskedCommand($cmdArgs);
+    Write-VerboseWithMaskedCommand $octopusServerExePath $cmdArgs
 
     $LASTEXITCODE = 0
     $output = & $octopusServerExePath $cmdArgs 2>&1
@@ -200,7 +200,7 @@ function Test-TentacleExecutableExists {
 
 function Invoke-TentacleCommand ($cmdArgs) {
 
-    Write-VerboseWithMaskedCommand($cmdArgs);
+    Write-VerboseWithMaskedCommand $tentacleExePath $cmdArgs
 
     $LASTEXITCODE = 0
     $output = & $tentacleExePath $cmdArgs 2>&1


### PR DESCRIPTION

Happened to notice this while looking at a customers log file:
![image](https://user-images.githubusercontent.com/373389/116633965-30961080-a99e-11eb-920e-9f23f1b11401.png)

We were always saying we are executing octopus.server.exe, even when we were actually executing tentacle.exe

cc'ing you, @paulegradie as an fyi - brackets around params when calling functions means different things in powershell
