### PR TITLE
Fix Tentacle only being searched for in the default install location

### DIFF
--- a/OctopusDSC/DSCResources/cOctopusSeqLogger/cOctopusSeqLogger.psm1
+++ b/OctopusDSC/DSCResources/cOctopusSeqLogger/cOctopusSeqLogger.psm1
@@ -1,8 +1,8 @@
-$octopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-$tentacleExePath = "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe"
-
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
+
+$octopusServerExePath = Get-OctopusServerExePath
+$tentacleExePath = Get-TentacleExePath
 
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]

--- a/OctopusDSC/DSCResources/cOctopusSeqLogger/cOctopusSeqLogger.psm1
+++ b/OctopusDSC/DSCResources/cOctopusSeqLogger/cOctopusSeqLogger.psm1
@@ -1,9 +1,6 @@
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
 
-$octopusServerExePath = Get-OctopusServerExePath
-$tentacleExePath = Get-TentacleExePath
-
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [OutputType([HashTable])]
@@ -100,9 +97,11 @@ function Get-TargetResourceInternal {
         [int]$ConfigVersion
     )
 
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -Path $octopusServerExePath) -and ($InstanceType -eq "OctopusServer") -and ($Ensure -eq "Present")) {
         throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
     }
+    $tentacleExePath = Get-TentacleExePath
     if (-not (Test-Path -Path $tentacleExePath) -and ($InstanceType -eq "Tentacle") -and ($Ensure -eq "Present")) {
         throw "Unable to find Tentacle (checked for existence of file '$tentacleExePath')."
     }
@@ -226,9 +225,11 @@ function Set-TargetResourceInternal {
     }
 
     if ($InstanceType -eq "Tentacle") {
+        $tentacleExePath = Get-TentacleExePath
         $nlogConfigFile = "$tentacleExePath.nlog"
     }
     elseif ($InstanceType -eq "OctopusServer") {
+        $octopusServerExePath = Get-OctopusServerExePath
         $nlogConfigFile = "$octopusServerExePath.nlog"
     }
 

--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
@@ -1,9 +1,10 @@
 $ErrorActionPreference = "Stop"
-$octopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
 $script:instancecontext = ''  # a global to hold the name of the current instance's context
 
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
+
+$octopusServerExePath = Get-OctopusServerExePath
 
 function Resolve-OctopusDSCError
 {

--- a/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServer/cOctopusServer.psm1
@@ -4,8 +4,6 @@ $script:instancecontext = ''  # a global to hold the name of the current instanc
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
 
-$octopusServerExePath = Get-OctopusServerExePath
-
 function Resolve-OctopusDSCError
 {
     param (
@@ -351,6 +349,7 @@ function Test-OctopusVersionSupportsDatabaseUpgrade {
 }
 
 function Test-OctopusVersionNewerThan($targetVersion) {
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Octopus.Server.exe path '$octopusServerExePath' does not exist."
     }

--- a/OctopusDSC/DSCResources/cOctopusServerActiveDirectoryAuthentication/cOctopusServerActiveDirectoryAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerActiveDirectoryAuthentication/cOctopusServerActiveDirectoryAuthentication.psm1
@@ -1,8 +1,6 @@
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
 
-$octopusServerExePath = Get-OctopusServerExePath
-
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [OutputType([Hashtable])]
@@ -16,6 +14,7 @@ function Get-TargetResource {
         [string]$ActiveDirectoryContainer
     )
     # check octopus installed
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
     }
@@ -94,6 +93,7 @@ function Test-TargetResource {
 
 
 function Test-OctopusVersionSupportsAuthenticationProvider {
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Octopus.Server.exe path '$octopusServerExePath' does not exist."
     }

--- a/OctopusDSC/DSCResources/cOctopusServerActiveDirectoryAuthentication/cOctopusServerActiveDirectoryAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerActiveDirectoryAuthentication/cOctopusServerActiveDirectoryAuthentication.psm1
@@ -1,7 +1,7 @@
-$octopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
+
+$octopusServerExePath = Get-OctopusServerExePath
 
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]

--- a/OctopusDSC/DSCResources/cOctopusServerAzureADAuthentication/cOctopusServerAzureADAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerAzureADAuthentication/cOctopusServerAzureADAuthentication.psm1
@@ -1,7 +1,7 @@
-$octopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
+
+$octopusServerExePath = Get-OctopusServerExePath
 
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]

--- a/OctopusDSC/DSCResources/cOctopusServerAzureADAuthentication/cOctopusServerAzureADAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerAzureADAuthentication/cOctopusServerAzureADAuthentication.psm1
@@ -1,8 +1,6 @@
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
 
-$octopusServerExePath = Get-OctopusServerExePath
-
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [OutputType([Hashtable])]
@@ -16,6 +14,7 @@ function Get-TargetResource {
         [string]$ClientId
     )
     # check octopus installed
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
     }
@@ -92,6 +91,7 @@ function Test-TargetResource {
     return $currentConfigurationMatchesRequestedConfiguration
 }
 function Test-OctopusVersionSupportsAuthenticationProvider {
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Octopus.Server.exe path '$octopusServerExePath' does not exist."
     }

--- a/OctopusDSC/DSCResources/cOctopusServerGoogleAppsAuthentication/cOctopusServerGoogleAppsAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerGoogleAppsAuthentication/cOctopusServerGoogleAppsAuthentication.psm1
@@ -1,7 +1,7 @@
-$octopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
+
+$octopusServerExePath = Get-OctopusServerExePath
 
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]

--- a/OctopusDSC/DSCResources/cOctopusServerGoogleAppsAuthentication/cOctopusServerGoogleAppsAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerGoogleAppsAuthentication/cOctopusServerGoogleAppsAuthentication.psm1
@@ -1,8 +1,6 @@
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
 
-$octopusServerExePath = Get-OctopusServerExePath
-
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [OutputType([Hashtable])]
@@ -16,6 +14,7 @@ function Get-TargetResource {
         [string]$HostedDomain
     )
     # check octopus installed
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
     }
@@ -93,6 +92,7 @@ function Test-TargetResource {
 }
 
 function Test-OctopusVersionSupportsAuthenticationProvider {
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Octopus.Server.exe path '$octopusServerExePath' does not exist."
     }

--- a/OctopusDSC/DSCResources/cOctopusServerGuestAuthentication/cOctopusServerGuestAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerGuestAuthentication/cOctopusServerGuestAuthentication.psm1
@@ -1,8 +1,6 @@
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
 
-$octopusServerExePath = Get-OctopusServerExePath
-
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [OutputType([Hashtable])]
@@ -14,6 +12,7 @@ function Get-TargetResource {
         [boolean]$Enabled
     )
     # check octopus installed
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
     }
@@ -81,6 +80,7 @@ function Test-TargetResource {
 }
 
 function Test-OctopusVersionSupportsAuthenticationProvider {
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Octopus.Server.exe path '$octopusServerExePath' does not exist."
     }

--- a/OctopusDSC/DSCResources/cOctopusServerGuestAuthentication/cOctopusServerGuestAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerGuestAuthentication/cOctopusServerGuestAuthentication.psm1
@@ -1,7 +1,7 @@
-$octopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
+
+$octopusServerExePath = Get-OctopusServerExePath
 
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]

--- a/OctopusDSC/DSCResources/cOctopusServerOktaAuthentication/cOctopusServerOktaAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerOktaAuthentication/cOctopusServerOktaAuthentication.psm1
@@ -1,7 +1,7 @@
-$octopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
+
+$octopusServerExePath = Get-OctopusServerExePath
 
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]

--- a/OctopusDSC/DSCResources/cOctopusServerOktaAuthentication/cOctopusServerOktaAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerOktaAuthentication/cOctopusServerOktaAuthentication.psm1
@@ -1,8 +1,6 @@
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
 
-$octopusServerExePath = Get-OctopusServerExePath
-
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [OutputType([Hashtable])]
@@ -16,6 +14,7 @@ function Get-TargetResource {
         [string]$ClientId
     )
     # check octopus installed
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
     }
@@ -93,6 +92,7 @@ function Test-TargetResource {
 }
 
 function Test-OctopusVersionSupportsOktaAuthenticationProvider {
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Octopus.Server.exe path '$octopusServerExePath' does not exist."
     }

--- a/OctopusDSC/DSCResources/cOctopusServerUsernamePasswordAuthentication/cOctopusServerUsernamePasswordAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerUsernamePasswordAuthentication/cOctopusServerUsernamePasswordAuthentication.psm1
@@ -1,8 +1,6 @@
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
 
-$octopusServerExePath = Get-OctopusServerExePath
-
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [OutputType([Hashtable])]
@@ -14,6 +12,7 @@ function Get-TargetResource {
         [boolean]$Enabled
     )
     # check octopus installed
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
     }
@@ -81,6 +80,7 @@ function Test-TargetResource {
 }
 
 function Test-OctopusVersionSupportsAuthenticationProvider {
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Octopus.Server.exe path '$octopusServerExePath' does not exist."
     }

--- a/OctopusDSC/DSCResources/cOctopusServerUsernamePasswordAuthentication/cOctopusServerUsernamePasswordAuthentication.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerUsernamePasswordAuthentication/cOctopusServerUsernamePasswordAuthentication.psm1
@@ -1,7 +1,7 @@
-$octopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
+
+$octopusServerExePath = Get-OctopusServerExePath
 
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]

--- a/OctopusDSC/DSCResources/cOctopusServerWatchdog/cOctopusServerWatchdog.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerWatchdog/cOctopusServerWatchdog.psm1
@@ -1,7 +1,7 @@
-$octopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
+
+$octopusServerExePath = Get-OctopusServerExePath
 
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]

--- a/OctopusDSC/DSCResources/cOctopusServerWatchdog/cOctopusServerWatchdog.psm1
+++ b/OctopusDSC/DSCResources/cOctopusServerWatchdog/cOctopusServerWatchdog.psm1
@@ -1,8 +1,6 @@
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
 
-$octopusServerExePath = Get-OctopusServerExePath
-
 function Get-TargetResource {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
     [OutputType([Hashtable])]
@@ -16,6 +14,7 @@ function Get-TargetResource {
         [string]$Instances = "*"
     )
     # check octopus installed
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
     }
@@ -100,6 +99,7 @@ function Test-TargetResource {
 }
 
 function Test-OctopusVersionSupportsWatchdogInShowConfiguration {
+    $octopusServerExePath = Get-OctopusServerExePath
     if (-not (Test-Path -LiteralPath $octopusServerExePath)) {
         throw "Octopus.Server.exe path '$octopusServerExePath' does not exist."
     }

--- a/OctopusDSC/DSCResources/cTentacleWatchdog/cTentacleWatchdog.psm1
+++ b/OctopusDSC/DSCResources/cTentacleWatchdog/cTentacleWatchdog.psm1
@@ -1,8 +1,6 @@
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
 
-$tentacleExePath = Get-TentacleExePath
-
 function Get-TargetResource
 {
   [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCUseVerboseMessageInDSCResource", "")]
@@ -17,6 +15,7 @@ function Get-TargetResource
     [string]$Instances = "*"
   )
   # check octopus installed
+  $tentacleExePath = Get-TentacleExePath
   if (-not (Test-Path -LiteralPath $tentacleExePath)) {
     throw "Unable to find Tentacle (checked for existence of file '$tentacleExePath')."
   }
@@ -107,6 +106,7 @@ function Test-TargetResource
 
 function Test-TentacleSupportsShowConfiguration
 {
+  $tentacleExePath = Get-TentacleExePath
   if (-not (Test-Path -LiteralPath $tentacleExePath))
   {
     throw "Tentacle.exe path '$tentacleExePath' does not exist."

--- a/OctopusDSC/DSCResources/cTentacleWatchdog/cTentacleWatchdog.psm1
+++ b/OctopusDSC/DSCResources/cTentacleWatchdog/cTentacleWatchdog.psm1
@@ -1,7 +1,7 @@
-$tentacleExePath = "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe"
-
 # dot-source the helper file (cannot load as a module due to scope considerations)
 . (Join-Path -Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -ChildPath 'OctopusDSCHelpers.ps1')
+
+$tentacleExePath = Get-TentacleExePath
 
 function Get-TargetResource
 {

--- a/OctopusDSC/OctopusDSCHelpers.ps1
+++ b/OctopusDSC/OctopusDSCHelpers.ps1
@@ -196,7 +196,7 @@ function Write-VerboseWithMaskedCommand ($exePath, $cmdArgs) {
 }
 
 function Invoke-OctopusServerCommand ($cmdArgs) {
-
+    $octopusServerExePath = Get-OctopusServerExePath
     Write-VerboseWithMaskedCommand $octopusServerExePath $cmdArgs
 
     $LASTEXITCODE = 0
@@ -211,15 +211,16 @@ function Invoke-OctopusServerCommand ($cmdArgs) {
 }
 
 function Test-TentacleExecutableExists {
-    return (test-path Get-TentacleExePath)
+    $tentacleExePath =  Get-TentacleExePath
+    return (test-path $tentacleExePath)
 }
 
 function Invoke-TentacleCommand ($cmdArgs) {
-
-    Write-VerboseWithMaskedCommand Get-TentacleExePath $cmdArgs
+    $tentacleExePath =  Get-TentacleExePath
+    Write-VerboseWithMaskedCommand $tentacleExePath $cmdArgs
 
     $LASTEXITCODE = 0
-    $output = & Get-TentacleExePath $cmdArgs 2>&1
+    $output = & $tentacleExePath $cmdArgs 2>&1
 
     Write-CommandOutput $output
     if (($null -ne $LASTEXITCODE) -and ($LASTEXITCODE -ne 0)) {
@@ -246,6 +247,7 @@ function Write-CommandOutput {
 }
 
 function Get-ServerConfiguration($instanceName) {
+    $octopusServerExePath = Get-OctopusServerExePath
     $rawConfig = & $octopusServerExePath show-configuration --format=json-hierarchical --noconsolelogging --console --instance $instanceName
 
     # handle a specific error where an exception in registry migration finds its way into the json-hierarchical output
@@ -276,9 +278,10 @@ function Get-ServerConfiguration($instanceName) {
 
 function Get-TentacleConfiguration($instanceName)
 {
-  $rawConfig = & Get-TentacleExePath show-configuration --instance $instanceName
-  $config = $rawConfig | ConvertFrom-Json
-  return $config
+    $tentacleExePath =  Get-TentacleExePath
+    $rawConfig = & $tentacleExePath show-configuration --instance $instanceName
+    $config = $rawConfig | ConvertFrom-Json
+    return $config
 }
 
 function Test-ValidJson

--- a/OctopusDSC/OctopusDSCHelpers.ps1
+++ b/OctopusDSC/OctopusDSCHelpers.ps1
@@ -1,7 +1,5 @@
 # Module contains shared code for OctopusDSC
 
-$octopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-
 function Get-OctopusServerExePath {
     $installLocation = (Get-ItemProperty -path "HKLM:\Software\Octopus\OctopusServer" -ErrorAction SilentlyContinue).InstallLocation
 

--- a/OctopusDSC/OctopusDSCHelpers.ps1
+++ b/OctopusDSC/OctopusDSCHelpers.ps1
@@ -7,17 +7,17 @@ function Get-OctopusServerExePath {
         return "$installLocation\Octopus.Server.exe"
     }
 
-    return ""
+    return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
 }
 
 function Get-TentacleExePath {
     $installLocation = (Get-ItemProperty -path "HKLM:\Software\Octopus\Tentacle" -ErrorAction SilentlyContinue).InstallLocation
 
     if ($installLocation -ne $null) {
-        return "$installLocation\tentacle.exe"
+        return "$installLocation\Tentacle.exe"
     }
 
-    return ""
+    return "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe"
 }
 
 function Get-ODSCParameter($parameters) {

--- a/OctopusDSC/Tests/OctopusDSCHelpers.Tests.ps1
+++ b/OctopusDSC/Tests/OctopusDSCHelpers.Tests.ps1
@@ -63,8 +63,7 @@ Describe "Invoke-OctopusServerCommand" {
     Context "It should not leak passwords" {
 
         BeforeAll {
-            $octopusServerExePath = "echo"
-            Write-Output "Mocked OctopusServerExePath as $OctopusServerExePath"
+            Mock Get-OctopusServerExePath { return "echo" }
             Mock Write-Verbose { } -verifiable
             Mock Write-CommandOutput {}
         }

--- a/OctopusDSC/Tests/cOctopusSeqLogger.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusSeqLogger.Tests.ps1
@@ -36,6 +36,7 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns expected data for valid config' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $true }
@@ -52,6 +53,7 @@ try
                 }
 
                 It 'Returns expected data for old sync config' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $true }
@@ -68,6 +70,7 @@ try
                 }
 
                 It 'Returns expected data when config not set' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $true }
@@ -82,6 +85,7 @@ try
                 }
 
                 It 'Returns expected data when dll does not exist' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $false }
@@ -97,20 +101,20 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed and ensure is set to present' {
-                    Mock Test-Path { return $false } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $false } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
+                    Mock Get-OctopusServerExePath { return "" }
+                    Mock Get-TentacleExePath { return "" }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
-                    { Get-TargetResourceInternal @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResourceInternal @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
                 }
 
                 It 'Does not throw an exception if Octopus is not installed and ensure is set to absent' {
-                    Mock Test-Path { return $false } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $false } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
+                    Mock Get-OctopusServerExePath { return "" }
+                    Mock Get-TentacleExePath { return "" }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
                     $desiredConfiguration.Ensure = 'Absent'
-                    { Get-TargetResourceInternal @desiredConfiguration } | Should -not -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResourceInternal @desiredConfiguration } | Should -not -throw "Unable to find Octopus (checked for existence of file '')."
                 }
             }
 
@@ -323,6 +327,7 @@ try
                 It 'Calls Get-TargetResource (and therefore inherits its checks)' {
                     $response = @{ InstanceType="OctopusServer"; Ensure='Present'; SeqServer = 'https://seq.example.com' }
                     Mock Get-TargetResourceInternal { return $response }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
                     Mock Request-SeqClientNlogDll
@@ -332,8 +337,8 @@ try
                 }
 
                 It 'Deletes the dll if it exists and ensure is set to absent' {
+                    Mock Get-OctopusServerExePath { return "" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
-                    Mock Test-Path { return $false } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Remove-Item
                     Set-TargetResourceInternal -InstanceType 'OctopusServer' -Ensure 'Absent'
                     Assert-MockCalled Remove-Item -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
@@ -341,6 +346,7 @@ try
 
                 It 'Removes the settings from the nlog config file if ensure is set to absent' {
                     #octopus is installed
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is NOT installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
@@ -359,6 +365,7 @@ try
 
                 It 'Removes the settings from the nlog config file if ensure is set to absent when config is the old sync version' {
                     #octopus is installed
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is NOT installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
@@ -377,6 +384,7 @@ try
 
                 It 'Downloads the dll if it doesnt exist and ensure is set to present' {
                     #octopus is installed
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is NOT installed
                     Mock Test-Path { return $false } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
@@ -392,6 +400,7 @@ try
 
                 It 'Add the settings to the nlog config file if ensure is set to present with no api key' {
                     #octopus is installed
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is NOT installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
@@ -411,6 +420,7 @@ try
 
                 It 'Add the settings to the nlog config file if ensure is set to present with an api key' {
                     #octopus is installed
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
@@ -433,6 +443,7 @@ try
 
                 It 'Updates the settings in the nlog config file if config is version 1' {
                     #octopus is installed
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
@@ -455,6 +466,7 @@ try
 
                 It 'Throws if ensure is set to present and SeqServer is not supplied' {
                     #octopus is installed
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }

--- a/OctopusDSC/Tests/cOctopusSeqLogger.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusSeqLogger.Tests.ps1
@@ -105,7 +105,7 @@ try
                     Mock Test-Path { return $false } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
-                    { Get-TargetResourceInternal @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
+                    { Get-TargetResourceInternal @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe')."
                 }
 
                 It 'Does not throw an exception if Octopus is not installed and ensure is set to absent' {
@@ -114,7 +114,7 @@ try
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
                     $desiredConfiguration.Ensure = 'Absent'
-                    { Get-TargetResourceInternal @desiredConfiguration } | Should -not -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
+                    { Get-TargetResourceInternal @desiredConfiguration } | Should -not -throw "Unable to find Octopus (checked for existence of file '$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe')."
                 }
             }
 

--- a/OctopusDSC/Tests/cOctopusSeqLogger.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusSeqLogger.Tests.ps1
@@ -16,8 +16,6 @@ try
         BeforeAll {
             $sampleConfigPath = Split-Path $PSCommandPath -Parent
             $sampleConfigPath = Join-Path $sampleConfigPath "SampleConfigs"
-
-            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
         }
 
         Describe 'cOctopusSeqLogger' {
@@ -38,8 +36,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns expected data for valid config' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
@@ -55,8 +53,8 @@ try
                 }
 
                 It 'Returns expected data for old sync config' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-old-sync-configuration-with-api-key.xml")) }
@@ -72,8 +70,8 @@ try
                 }
 
                 It 'Returns expected data when config not set' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-when-not-configured.xml")) }
@@ -87,8 +85,8 @@ try
                 }
 
                 It 'Returns expected data when dll does not exist' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $false }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
@@ -103,20 +101,20 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed and ensure is set to present' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $false } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $false } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
-                    { Get-TargetResourceInternal @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
+                    { Get-TargetResourceInternal @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
                 }
 
                 It 'Does not throw an exception if Octopus is not installed and ensure is set to absent' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $false } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $false } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
                     $desiredConfiguration.Ensure = 'Absent'
-                    { Get-TargetResourceInternal @desiredConfiguration } | Should -not -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
+                    { Get-TargetResourceInternal @desiredConfiguration } | Should -not -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
                 }
             }
 
@@ -329,8 +327,8 @@ try
                 It 'Calls Get-TargetResource (and therefore inherits its checks)' {
                     $response = @{ InstanceType="OctopusServer"; Ensure='Present'; SeqServer = 'https://seq.example.com' }
                     Mock Get-TargetResourceInternal { return $response }
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
                     Mock Request-SeqClientNlogDll
                     Mock Save-NlogConfig
@@ -339,8 +337,8 @@ try
                 }
 
                 It 'Deletes the dll if it exists and ensure is set to absent' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     Mock Remove-Item
                     Set-TargetResourceInternal -InstanceType 'OctopusServer' -Ensure 'Absent'
@@ -349,8 +347,8 @@ try
 
                 It 'Removes the settings from the nlog config file if ensure is set to absent' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is NOT installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     # the nlog config file does exist
@@ -368,8 +366,8 @@ try
 
                 It 'Removes the settings from the nlog config file if ensure is set to absent when config is the old sync version' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is NOT installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     # the nlog config file does exist
@@ -387,8 +385,8 @@ try
 
                 It 'Downloads the dll if it doesnt exist and ensure is set to present' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is NOT installed
                     Mock Test-Path { return $false } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
@@ -403,8 +401,8 @@ try
 
                 It 'Add the settings to the nlog config file if ensure is set to present with no api key' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is NOT installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-when-not-configured.xml")) }
@@ -423,8 +421,8 @@ try
 
                 It 'Add the settings to the nlog config file if ensure is set to present with an api key' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-when-not-configured.xml")) }
@@ -446,8 +444,8 @@ try
 
                 It 'Updates the settings in the nlog config file if config is version 1' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-old-sync-configuration-with-api-key.xml")) }
@@ -469,8 +467,8 @@ try
 
                 It 'Throws if ensure is set to present and SeqServer is not supplied' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     # the nlog dll is installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     Mock Save-NlogConfig

--- a/OctopusDSC/Tests/cOctopusSeqLogger.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusSeqLogger.Tests.ps1
@@ -339,7 +339,8 @@ try
                 }
 
                 It 'Deletes the dll if it exists and ensure is set to absent' {
-                    Mock Get-OctopusServerExePath { return "" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     Mock Remove-Item
                     Set-TargetResourceInternal -InstanceType 'OctopusServer' -Ensure 'Absent'

--- a/OctopusDSC/Tests/cOctopusSeqLogger.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusSeqLogger.Tests.ps1
@@ -16,6 +16,8 @@ try
         BeforeAll {
             $sampleConfigPath = Split-Path $PSCommandPath -Parent
             $sampleConfigPath = Join-Path $sampleConfigPath "SampleConfigs"
+
+            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
         }
 
         Describe 'cOctopusSeqLogger' {
@@ -36,8 +38,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns expected data for valid config' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
@@ -53,8 +55,8 @@ try
                 }
 
                 It 'Returns expected data for old sync config' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-old-sync-configuration-with-api-key.xml")) }
@@ -70,8 +72,8 @@ try
                 }
 
                 It 'Returns expected data when config not set' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-when-not-configured.xml")) }
@@ -85,8 +87,8 @@ try
                 }
 
                 It 'Returns expected data when dll does not exist' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe.nlog" }
                     Mock Test-NLogDll { return $false }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
@@ -101,20 +103,20 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed and ensure is set to present' {
-                    Mock Get-OctopusServerExePath { return "" }
-                    Mock Get-TentacleExePath { return "" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $false } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
-                    { Get-TargetResourceInternal @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
+                    { Get-TargetResourceInternal @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
                 }
 
                 It 'Does not throw an exception if Octopus is not installed and ensure is set to absent' {
-                    Mock Get-OctopusServerExePath { return "" }
-                    Mock Get-TentacleExePath { return "" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $false } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     Mock Test-NLogDll { return $true }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
                     $desiredConfiguration.Ensure = 'Absent'
-                    { Get-TargetResourceInternal @desiredConfiguration } | Should -not -throw "Unable to find Octopus (checked for existence of file '')."
+                    { Get-TargetResourceInternal @desiredConfiguration } | Should -not -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
                 }
             }
 
@@ -327,8 +329,8 @@ try
                 It 'Calls Get-TargetResource (and therefore inherits its checks)' {
                     $response = @{ InstanceType="OctopusServer"; Ensure='Present'; SeqServer = 'https://seq.example.com' }
                     Mock Get-TargetResourceInternal { return $response }
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
                     Mock Request-SeqClientNlogDll
                     Mock Save-NlogConfig
@@ -346,8 +348,8 @@ try
 
                 It 'Removes the settings from the nlog config file if ensure is set to absent' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     # the nlog dll is NOT installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     # the nlog config file does exist
@@ -365,8 +367,8 @@ try
 
                 It 'Removes the settings from the nlog config file if ensure is set to absent when config is the old sync version' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     # the nlog dll is NOT installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     # the nlog config file does exist
@@ -384,8 +386,8 @@ try
 
                 It 'Downloads the dll if it doesnt exist and ensure is set to present' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     # the nlog dll is NOT installed
                     Mock Test-Path { return $false } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-valid-configuration-with-api-key.xml")) }
@@ -400,8 +402,8 @@ try
 
                 It 'Add the settings to the nlog config file if ensure is set to present with no api key' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     # the nlog dll is NOT installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-when-not-configured.xml")) }
@@ -420,8 +422,8 @@ try
 
                 It 'Add the settings to the nlog config file if ensure is set to present with an api key' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     # the nlog dll is installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-when-not-configured.xml")) }
@@ -443,8 +445,8 @@ try
 
                 It 'Updates the settings in the nlog config file if config is version 1' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     # the nlog dll is installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     Mock Get-NLogConfig { return  [xml] (Get-Content (Join-Path $sampleConfigPath "octopus.server.exe.nlog-with-old-sync-configuration-with-api-key.xml")) }
@@ -466,8 +468,8 @@ try
 
                 It 'Throws if ensure is set to present and SeqServer is not supplied' {
                     #octopus is installed
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $Path -eq $defaultOctopusServerExePath }
                     # the nlog dll is installed
                     Mock Test-Path { return $true } -ParameterFilter { $Path -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Seq.Client.NLog.dll" }
                     Mock Save-NlogConfig

--- a/OctopusDSC/Tests/cOctopusServerActiveDirectoryAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerActiveDirectoryAuthentication.Tests.ps1
@@ -50,7 +50,7 @@ try
                     Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {

--- a/OctopusDSC/Tests/cOctopusServerActiveDirectoryAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerActiveDirectoryAuthentication.Tests.ps1
@@ -11,10 +11,6 @@ try
     $module = Import-Module $script:modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
-        BeforeAll {
-            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-        }
-        
         Describe 'cOctopusServerActiveDirectoryAuthentication' {
             BeforeEach {
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
@@ -28,8 +24,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration {
                         return  @{
@@ -51,15 +47,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerActiveDirectoryAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerActiveDirectoryAuthentication.Tests.ps1
@@ -25,6 +25,7 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration {
@@ -47,12 +48,13 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return "" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."

--- a/OctopusDSC/Tests/cOctopusServerActiveDirectoryAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerActiveDirectoryAuthentication.Tests.ps1
@@ -11,7 +11,10 @@ try
     $module = Import-Module $script:modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
-
+        BeforeAll {
+            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
+        }
+        
         Describe 'cOctopusServerActiveDirectoryAuthentication' {
             BeforeEach {
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
@@ -25,8 +28,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration {
                         return  @{
@@ -48,14 +51,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return "" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerAzureADAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerAzureADAuthentication.Tests.ps1
@@ -50,7 +50,7 @@ try
                     Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {

--- a/OctopusDSC/Tests/cOctopusServerAzureADAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerAzureADAuthentication.Tests.ps1
@@ -11,6 +11,9 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
+        BeforeAll {
+            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
+        }
 
         Describe 'cOctopusServerAzureADAuthentication' {
             BeforeEach {
@@ -25,8 +28,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration {
                         return  @{
@@ -48,14 +51,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return "" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerAzureADAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerAzureADAuthentication.Tests.ps1
@@ -25,6 +25,7 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration {
@@ -47,12 +48,13 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return "" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."

--- a/OctopusDSC/Tests/cOctopusServerAzureADAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerAzureADAuthentication.Tests.ps1
@@ -11,10 +11,6 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
-        BeforeAll {
-            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-        }
-
         Describe 'cOctopusServerAzureADAuthentication' {
             BeforeEach {
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
@@ -28,8 +24,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration {
                         return  @{
@@ -51,15 +47,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerGoogleAppsAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerGoogleAppsAuthentication.Tests.ps1
@@ -12,10 +12,6 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
-        BeforeAll {
-            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-        }
-
         Describe 'cOctopusServerGoogleAppsAuthentication' {
             BeforeEach {
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
@@ -29,8 +25,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration {
                         return  @{
@@ -52,15 +48,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerGoogleAppsAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerGoogleAppsAuthentication.Tests.ps1
@@ -26,6 +26,7 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration {
@@ -48,12 +49,13 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return "" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."

--- a/OctopusDSC/Tests/cOctopusServerGoogleAppsAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerGoogleAppsAuthentication.Tests.ps1
@@ -51,7 +51,7 @@ try
                     Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {

--- a/OctopusDSC/Tests/cOctopusServerGuestAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerGuestAuthentication.Tests.ps1
@@ -36,7 +36,7 @@ try
                     Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {

--- a/OctopusDSC/Tests/cOctopusServerGuestAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerGuestAuthentication.Tests.ps1
@@ -11,6 +11,9 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
+        BeforeAll {
+            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
+        }
 
         Describe 'cOctopusServerGuestAuthentication' {
             BeforeEach {
@@ -23,8 +26,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration { return  @{Octopus = @{ WebPortal = @{ GuestLoginEnabled = $true }}} }
 
@@ -34,14 +37,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return "" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerGuestAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerGuestAuthentication.Tests.ps1
@@ -11,10 +11,6 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
-        BeforeAll {
-            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-        }
-
         Describe 'cOctopusServerGuestAuthentication' {
             BeforeEach {
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
@@ -26,8 +22,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration { return  @{Octopus = @{ WebPortal = @{ GuestLoginEnabled = $true }}} }
 
@@ -37,15 +33,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerGuestAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerGuestAuthentication.Tests.ps1
@@ -23,6 +23,7 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration { return  @{Octopus = @{ WebPortal = @{ GuestLoginEnabled = $true }}} }
@@ -33,12 +34,13 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return "" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."

--- a/OctopusDSC/Tests/cOctopusServerOktaAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerOktaAuthentication.Tests.ps1
@@ -50,7 +50,7 @@ try
                     Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsOktaAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {

--- a/OctopusDSC/Tests/cOctopusServerOktaAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerOktaAuthentication.Tests.ps1
@@ -11,6 +11,9 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
+        BeforeAll {
+            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
+        }
 
         Describe 'cOctopusServerOktaAuthentication' {
             BeforeEach {
@@ -25,8 +28,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsOktaAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration {
                         return  @{
@@ -48,14 +51,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return "" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsOktaAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsOktaAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.16.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerOktaAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerOktaAuthentication.Tests.ps1
@@ -11,10 +11,6 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
-        BeforeAll {
-            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-        }
-
         Describe 'cOctopusServerOktaAuthentication' {
             BeforeEach {
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
@@ -28,8 +24,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsOktaAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration {
                         return  @{
@@ -51,15 +47,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsOktaAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsOktaAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.16.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerOktaAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerOktaAuthentication.Tests.ps1
@@ -25,6 +25,7 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsOktaAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration {
@@ -47,12 +48,13 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return "" }
                     Mock Test-OctopusVersionSupportsOktaAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsOktaAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.16.0+."

--- a/OctopusDSC/Tests/cOctopusServerUsernamePasswordAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerUsernamePasswordAuthentication.Tests.ps1
@@ -36,7 +36,7 @@ try
                     Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {

--- a/OctopusDSC/Tests/cOctopusServerUsernamePasswordAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerUsernamePasswordAuthentication.Tests.ps1
@@ -11,10 +11,6 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
-        BeforeAll {
-            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-        }
-
         Describe 'cOctopusServerUsernamePasswordAuthentication' {
             BeforeEach {
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
@@ -26,8 +22,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration { return  @{Octopus = @{ UsernamePassword = @{ IsEnabled = $true }}} }
 
@@ -37,15 +33,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerUsernamePasswordAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerUsernamePasswordAuthentication.Tests.ps1
@@ -11,6 +11,9 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
+        BeforeAll {
+            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
+        }
 
         Describe 'cOctopusServerUsernamePasswordAuthentication' {
             BeforeEach {
@@ -23,8 +26,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration { return  @{Octopus = @{ UsernamePassword = @{ IsEnabled = $true }}} }
 
@@ -34,14 +37,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return "" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerUsernamePasswordAuthentication.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerUsernamePasswordAuthentication.Tests.ps1
@@ -23,6 +23,7 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
                     Mock Get-ServerConfiguration { return  @{Octopus = @{ UsernamePassword = @{ IsEnabled = $true }}} }
@@ -33,12 +34,13 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return "" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsAuthenticationProvider { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.5.0+."

--- a/OctopusDSC/Tests/cOctopusServerWatchdog.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerWatchdog.Tests.ps1
@@ -11,6 +11,9 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
+        BeforeAll {
+            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
+        }
 
         Describe 'cOctopusServerWatchdog' {
             BeforeEach {
@@ -25,8 +28,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsWatchdogInShowConfiguration { return $true }
                     Mock Get-ServerConfiguration {
                         return  @{
@@ -48,14 +51,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return "" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsWatchdogInShowConfiguration { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
                     Mock Test-OctopusVersionSupportsWatchdogInShowConfiguration { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.17.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerWatchdog.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerWatchdog.Tests.ps1
@@ -25,6 +25,7 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsWatchdogInShowConfiguration { return $true }
                     Mock Get-ServerConfiguration {
@@ -47,12 +48,13 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Get-OctopusServerExePath { return "" }
                     Mock Test-OctopusVersionSupportsWatchdogInShowConfiguration { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$octopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsWatchdogInShowConfiguration { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.17.0+."

--- a/OctopusDSC/Tests/cOctopusServerWatchdog.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerWatchdog.Tests.ps1
@@ -11,10 +11,6 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
-        BeforeAll {
-            $defaultOctopusServerExePath = "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"
-        }
-
         Describe 'cOctopusServerWatchdog' {
             BeforeEach {
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
@@ -28,8 +24,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsWatchdogInShowConfiguration { return $true }
                     Mock Get-ServerConfiguration {
                         return  @{
@@ -51,15 +47,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsWatchdogInShowConfiguration { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$defaultOctopusServerExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {
-                    Mock Get-OctopusServerExePath { return $defaultOctopusServerExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultOctopusServerExePath }
+                    Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsWatchdogInShowConfiguration { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Octopus Deploy 3.17.0+."
                 }

--- a/OctopusDSC/Tests/cOctopusServerWatchdog.Tests.ps1
+++ b/OctopusDSC/Tests/cOctopusServerWatchdog.Tests.ps1
@@ -50,7 +50,7 @@ try
                     Mock Get-OctopusServerExePath { return "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe" }
                     Mock Test-OctopusVersionSupportsWatchdogInShowConfiguration { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '"$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe"')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Octopus (checked for existence of file '$($env:ProgramFiles)\Octopus Deploy\Octopus\Octopus.Server.exe')."
                 }
 
                 It 'Throws an exception if its an old version of Octopus' {

--- a/OctopusDSC/Tests/cTentacleWatchdog.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleWatchdog.Tests.ps1
@@ -24,8 +24,8 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
-                    Mock Get-TentacleExePath { return $defaultTentacleExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultTentacleExePath }
+                    Mock Get-TentacleExePath { return "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe" }
                     Mock Test-TentacleSupportsShowConfiguration { return $true }
                     Mock Get-TentacleConfiguration {
                         return  @{
@@ -47,15 +47,15 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Get-TentacleExePath { return $defaultTentacleExePath }
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq $defaultTentacleExePath }
+                    Mock Get-TentacleExePath { return "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe" }
+                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe" }
                     Mock Test-TentacleSupportsShowConfiguration { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Tentacle (checked for existence of file '$defaultTentacleExePath')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Tentacle (checked for existence of file '$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe')."
                 }
 
                 It 'Throws an exception if its an old version of Tentacle' {
-                    Mock Get-TentacleExePath { return $defaultTentacleExePath }
-                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq $defaultTentacleExePath }
+                    Mock Get-TentacleExePath { return "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe" }
+                    Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe" }
                     Mock Test-TentacleSupportsShowConfiguration { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Tentacle 3.15.8+."
                 }

--- a/OctopusDSC/Tests/cTentacleWatchdog.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleWatchdog.Tests.ps1
@@ -25,6 +25,7 @@ try
 
             Context 'Get-TargetResource' {
                 It 'Returns the proper data' {
+                    Mock Get-TentacleExePath { return "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe" }
                     Mock Test-TentacleSupportsShowConfiguration { return $true }
                     Mock Get-TentacleConfiguration {
@@ -47,12 +48,13 @@ try
                 }
 
                 It 'Throws an exception if Octopus is not installed' {
-                    Mock Test-Path { return $false } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe" }
+                    Mock Get-TentacleExePath { return "" }
                     Mock Test-TentacleSupportsShowConfiguration { return $true }
-                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Tentacle (checked for existence of file '$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe')."
+                    { Get-TargetResource @desiredConfiguration } | Should -throw "Unable to find Tentacle (checked for existence of file '')."
                 }
 
                 It 'Throws an exception if its an old version of Tentacle' {
+                    Mock Get-TentacleExePath { return "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe" }
                     Mock Test-Path { return $true } -ParameterFilter { $LiteralPath -eq "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe" }
                     Mock Test-TentacleSupportsShowConfiguration { return $false }
                     { Get-TargetResource @desiredConfiguration } | Should -throw "This resource only supports Tentacle 3.15.8+."

--- a/OctopusDSC/Tests/cTentacleWatchdog.Tests.ps1
+++ b/OctopusDSC/Tests/cTentacleWatchdog.Tests.ps1
@@ -11,10 +11,6 @@ try
     $module = Import-Module $modulePath -Prefix $prefix -PassThru -ErrorAction Stop
 
     InModuleScope $module.Name {
-        BeforeAll {
-            $defaultTentacleExePath = "$($env:ProgramFiles)\Octopus Deploy\Tentacle\Tentacle.exe"
-        }
-
         Describe 'cTentacleWatchdog' {
             BeforeEach {
                 [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/OctopusDSC/issues/276

Steps to reproduce:
1. Given no Tentacle is installed
2. Run the sample config eg. https://github.com/OctopusDeploy/OctopusDSC/blob/master/README-cTentacleAgent.md which should install Tentacle to the default location
2. Open `Registry Editor` and update the following to a different location (eg. `D:\Octopus Deploy\Tentacle`)
  i. HKEY_LOCAL_MACHINE\SOFTWARE\Octopus\Tentacle\InstallLocation
  ii. HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\OctopusDeploy Tentacle\ImagePath
3. Open `Services` and stop the OctopusDeploy Tentacle service
4. Move the contents of the Tentacle installation to the new location
5. Run the sample config again

Previously, these steps would produce the following error:
```
The term 'C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe' is not recognized as the name of a cmdlet, function,
script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is
correct and try again.
```

With the changes on this branch the second run should complete with no errors.