### PR TITLE
Use G-Zip for requesting machines/all

### DIFF
--- a/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
+++ b/OctopusDSC/DSCResources/cTentacleAgent/cTentacleAgent.psm1
@@ -29,7 +29,7 @@ function Get-APIResult {
     $apiEndpoint = "{0}api{1}" -f $ServerUrl, $API
 
     # Call API and capture results
-    $results = Invoke-WebRequest -Uri $apiEndpoint -Headers @{"X-Octopus-ApiKey"="$APIKey"} -UseBasicParsing
+    $results = Invoke-WebRequest -Uri $apiEndpoint -Headers @{"X-Octopus-ApiKey"="$APIKey"; "Accept-Encoding"="gzip"} -UseBasicParsing
 
     # return the result
     return ConvertFrom-Json -InputObject $results


### PR DESCRIPTION
Requested by customer https://help.octopus.com/t/octopusdsc-use-gzip-when-talking-to-octopus-server/26766

Comparing download responses:

### Old

```
$nonCompressedResults = Invoke-WebRequest -Uri https://example.octopus.app/api/machines/all -Headers @{"X-Octopus-ApiKey"="API-XXX"; } -UseBasicParsing
```

```
PS > $nonCompressedResults.Headers

Key                              Value
---                              -----
Date                             {Tue, 08 Jun 2021 05:56:12 GMT}
Transfer-Encoding                {chunked}
Connection                       {keep-alive}
Vary                             {Accept-Encoding}
Cache-Control                    {private}
Access-Control-Allow-Credentials {true}
Access-Control-Allow-Headers     {cache-control, content-type, x-http-method-override, X-Octopus-Data-Version, X-Octopus-Authorization-Hash, X-Octopus-ApiKey, X-Octopus-Csrf-Token, X-Octopus-User-Agent, X-MiniProfiler-Ids}
Access-Control-Allow-Methods     {GET, PUT, POST, DELETE, OPTIONS}
Access-Control-Allow-Origin      {*}
Access-Control-Expose-Headers    {X-Octopus-Data-Version, X-Octopus-Authorization-Hash, Octopus-Node}
Server-Timing                    {total;dur=45}
Content-Security-Policy          {default-src 'none'; connect-src https://octopus.com https://capture.trackjs.com https://telemetry.octopus.com 'self'; font-src 'self'; img-src data: https://usage.trackjs.com https://www.gravatar.com 'sel…
Octopus-Node                     {name=octopus-<snip>; version=2021.2.4391}
Referrer-Policy                  {no-referrer}
X-Content-Type-Options           {nosniff}
X-Frame-Options                  {DENY}
X-XSS-Protection                 {1; mode=block}
X-Robots-Tag                     {noindex, nofollow}
Strict-Transport-Security        {max-age=15724800; includeSubDomains}
Content-Type                     {application/json; charset=utf-8}
Allow                            {GET}
Expires                          {Mon, 07 Jun 2021 05:56:12 GMT}
```

### New
```
$compressedResults = Invoke-WebRequest -Uri https://example.octopus.app/api/machines/all -Headers @{"X-Octopus-ApiKey"="API-XXX"; "Accept-Encoding"="gzip"} -UseBasicParsing
```

gives:
```
PS > $compressedResults.headers

Key                              Value
---                              -----
Date                             {Tue, 08 Jun 2021 05:56:19 GMT}
Transfer-Encoding                {chunked}
Connection                       {keep-alive}
Cache-Control                    {private}
Vary                             {Accept-Encoding}
Access-Control-Allow-Credentials {true}
Access-Control-Allow-Headers     {cache-control, content-type, x-http-method-override, X-Octopus-Data-Version, X-Octopus-Authorization-Hash, X-Octopus-ApiKey, X-Octopus-Csrf-Token, X-Octopus-User-Agent, X-MiniProfiler-Ids}
Access-Control-Allow-Methods     {GET, PUT, POST, DELETE, OPTIONS}
Access-Control-Allow-Origin      {*}
Access-Control-Expose-Headers    {X-Octopus-Data-Version, X-Octopus-Authorization-Hash, Octopus-Node}
Server-Timing                    {total;dur=44}
Content-Security-Policy          {default-src 'none'; connect-src https://octopus.com https://capture.trackjs.com https://telemetry.octopus.com 'self'; font-src 'self'; img-src data: https://usage.trackjs.com https://www.gravatar.com 'sel…
Octopus-Node                     {name=octopus-<snip>; version=2021.2.4391}
Referrer-Policy                  {no-referrer}
X-Content-Type-Options           {nosniff}
X-Frame-Options                  {DENY}
X-XSS-Protection                 {1; mode=block}
X-Robots-Tag                     {noindex, nofollow}
Strict-Transport-Security        {max-age=15724800; includeSubDomains}
Content-Type                     {application/json; charset=utf-8}
Allow                            {GET}
Content-Encoding                 {gzip}
Expires                          {Mon, 07 Jun 2021 05:56:19 GMT}
```

Note the additonal 
```
Content-Encoding                 {gzip}
```

