### PR TITLE
Bump the aws base image to 20H2

### DIFF
--- a/build-aws.ps1
+++ b/build-aws.ps1
@@ -88,7 +88,7 @@ Write-Output "Adding vagrant box"
 vagrant box add OctopusDeploy/dsc-test-server-windows-server-20H2 https://s3-ap-southeast-2.amazonaws.com/octopus-vagrant-boxes/vagrant/json/OctopusDeploy/amazon-ebs/dsc-test-server-windows-server-20H2.json --force
 
 Write-Output "Ensuring vagrant box is latest"
-vagrant box update --box OctopusDeploy/dsc-test-server-windows-server-1909 --provider aws
+vagrant box update --box OctopusDeploy/dsc-test-server-windows-server-20H2 --provider aws
 
 $splat = @{
   provider="aws";

--- a/build-aws.ps1
+++ b/build-aws.ps1
@@ -85,7 +85,7 @@ if (Test-AppExists "chmod") {
 }
 
 Write-Output "Adding vagrant box"
-vagrant box add OctopusDeploy/dsc-test-server-windows-server-1909 https://s3-ap-southeast-2.amazonaws.com/octopus-vagrant-boxes/vagrant/json/OctopusDeploy/amazon-ebs/dsc-test-server-windows-server-1909.json --force
+vagrant box add OctopusDeploy/dsc-test-server-windows-server-20H2 https://s3-ap-southeast-2.amazonaws.com/octopus-vagrant-boxes/vagrant/json/OctopusDeploy/amazon-ebs/dsc-test-server-windows-server-20H2.json --force
 
 Write-Output "Ensuring vagrant box is latest"
 vagrant box update --box OctopusDeploy/dsc-test-server-windows-server-1909 --provider aws

--- a/cleanup-aws.ps1
+++ b/cleanup-aws.ps1
@@ -35,6 +35,12 @@ $keyName = $files[0].BaseName
 $env:KEY_NAME = $keyName
 Write-Output "Using key pair $keyName.pem"
 
+# this is a global action, so it doesn't get saved outside of the docker container when running
+Write-Output "Adding vagrant box"
+vagrant box add OctopusDeploy/dsc-test-server-windows-server-20H2 https://s3-ap-southeast-2.amazonaws.com/octopus-vagrant-boxes/vagrant/json/OctopusDeploy/amazon-ebs/dsc-test-server-windows-server-20H2.json --force
+Write-Output "Ensuring vagrant box is latest"
+vagrant box update --box OctopusDeploy/dsc-test-server-windows-server-20H2 --provider aws
+
 #todo: check vagrant status and exit cleanly if not running
 
 Write-Output "Running 'vagrant destroy -f'"

--- a/vagrantfile
+++ b/vagrantfile
@@ -133,7 +133,7 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
     aws.subnet_id = aws_subnet_id
     aws.associate_public_ip = true
     aws.user_data = File.read("Tests/aws_user_data.ps1")
-    override.vm.box = "OctopusDeploy/dsc-test-server-windows-server-1909" #box added via launcher script
+    override.vm.box = "OctopusDeploy/dsc-test-server-windows-server-20H2" #box added via launcher script
     override.ssh.private_key_path = "./#{aws_key_name}.pem"
     override.winrm.username = "Administrator"
     override.winrm.timeout = 180


### PR DESCRIPTION
Update the base image to 20H2 - the old image we were using (1909) got replaced a while back, and these updates got missed.

This also slightly modifies the cleanup script so that it re-adds the vagrant box, so we can run the steps in docker containers.
Adding the box is a global action - it's stored outside the working directory. Previously, we ran both steps on the same VM, meaning global actions remained between the "run" and "cleanup" steps. Running in a docker container meant that the global action was scoped to a step only.