### PR TITLE
Use windows 2019 test image

### DIFF
--- a/build-aws.ps1
+++ b/build-aws.ps1
@@ -68,10 +68,10 @@ if (Test-AppExists "chmod") {
 }
 
 Write-Output "Adding vagrant box"
-vagrant box add OctopusDeploy/dsc-test-server-windows-server-20H2 https://s3-ap-southeast-2.amazonaws.com/octopus-vagrant-boxes/vagrant/json/OctopusDeploy/amazon-ebs/dsc-test-server-windows-server-20H2.json --force
+vagrant box add OctopusDeploy/dsc-test-server-windows-server-2019 https://s3-ap-southeast-2.amazonaws.com/octopus-vagrant-boxes/vagrant/json/OctopusDeploy/amazon-ebs/dsc-test-server-windows-server-2019.json --force
 
 Write-Output "Ensuring vagrant box is latest"
-vagrant box update --box OctopusDeploy/dsc-test-server-windows-server-20H2 --provider aws
+vagrant box update --box OctopusDeploy/dsc-test-server-windows-server-2019 --provider aws
 
 $splat = @{
   provider="aws";

--- a/cleanup-aws.ps1
+++ b/cleanup-aws.ps1
@@ -37,9 +37,9 @@ Write-Output "Using key pair $keyName.pem"
 
 # this is a global action, so it doesn't get saved outside of the docker container when running
 Write-Output "Adding vagrant box"
-vagrant box add OctopusDeploy/dsc-test-server-windows-server-20H2 https://s3-ap-southeast-2.amazonaws.com/octopus-vagrant-boxes/vagrant/json/OctopusDeploy/amazon-ebs/dsc-test-server-windows-server-20H2.json --force
+vagrant box add OctopusDeploy/dsc-test-server-windows-server-2019 https://s3-ap-southeast-2.amazonaws.com/octopus-vagrant-boxes/vagrant/json/OctopusDeploy/amazon-ebs/dsc-test-server-windows-server-2019.json --force
 Write-Output "Ensuring vagrant box is latest"
-vagrant box update --box OctopusDeploy/dsc-test-server-windows-server-20H2 --provider aws
+vagrant box update --box OctopusDeploy/dsc-test-server-windows-server-2019 --provider aws
 
 #todo: check vagrant status and exit cleanly if not running
 

--- a/vagrantfile
+++ b/vagrantfile
@@ -107,8 +107,8 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
     v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
     v.customize ["modifyvm", :id, "--usb", "off"]
     v.customize ["modifyvm", :id, "--vram", "32"]
-    override.vm.box = "OctopusDeploy/dsc-test-server-windows-server-20H2"
-    override.vm.box_url = "https://s3-ap-southeast-2.amazonaws.com/octopus-vagrant-boxes/vagrant/json/OctopusDeploy/virtualbox/dsc-test-server-windows-server-20H2.json"
+    override.vm.box = "OctopusDeploy/dsc-test-server-windows-server-2019"
+    override.vm.box_url = "https://s3-ap-southeast-2.amazonaws.com/octopus-vagrant-boxes/vagrant/json/OctopusDeploy/virtualbox/dsc-test-server-windows-server-2019.json"
     override.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
     override.vm.network :forwarded_port, guest: 80,   host: 8000, id: "web"
     override.vm.network :forwarded_port, guest: 443, host: 8443,  id: "ssl"
@@ -149,7 +149,7 @@ Vagrant.configure(VAGRANT_FILE_API_VERSION) do |config|
     aws.subnet_id = aws_subnet_id
     aws.associate_public_ip = true
     aws.user_data = File.read("Tests/aws_user_data.ps1")
-    override.vm.box = "OctopusDeploy/dsc-test-server-windows-server-20H2" #box added via launcher script
+    override.vm.box = "OctopusDeploy/dsc-test-server-windows-server-2019" #box added via launcher script
     override.ssh.private_key_path = "./#{aws_key_name}.pem"
     override.winrm.username = "Administrator"
     override.winrm.timeout = 180


### PR DESCRIPTION
The `OctopusDeploy/dsc-test-server-windows-server-20H2` vagrant box is being decommissioned. This is to use the newer `OctopusDeploy/dsc-test-server-windows-server-2019` for testing.